### PR TITLE
Site Manager Dashboard : Added back to search results feature on Participant Details

### DIFF
--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -1,7 +1,6 @@
-import {renderParticipantDetails} from './participantDetails.js';
+import { renderParticipantDetails } from './participantDetails.js';
 import { animation, participantVerification } from './index.js'
 import fieldMapping from './fieldToConceptIdMapping.js'; 
-import { siteKeyToName } from './utils.js';
 import { keyToNameObj } from './siteKeysToName.js';
 export const importantColumns = [fieldMapping.fName, fieldMapping.mName, fieldMapping.lName, fieldMapping.birthMonth, fieldMapping.birthDay, fieldMapping.birthYear, fieldMapping.prefEmail, 'Connect_ID', fieldMapping.healthcareProvider];
 
@@ -204,11 +203,11 @@ const addEventShowMoreInfo = data => {
         element.addEventListener('click', () => {
             const filteredData = data.filter(dt => dt.token === element.dataset.token);
             console.log("select clicked", filteredData );
-            let adminSubjectAudit = []
-            let changedOption = {}
+            let adminSubjectAudit = [];
+            let changedOption = {};
             const loadDetailsPage = '#participantDetails'
+            location.replace(window.location.origin + window.location.pathname + loadDetailsPage); // updates url to participantDetails upon screen update
             renderParticipantDetails(filteredData[0], adminSubjectAudit, changedOption, JSON.parse(localStorage.dashboard).siteKey);
-            location.replace(window.location.origin + window.location.pathname + loadDetailsPage);        
         });
     });
 

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -1,8 +1,9 @@
-import {renderNavBarLinks, dashboardNavBarLinks, removeActiveClass} from './navigationBar.js';
+import { renderNavBarLinks, dashboardNavBarLinks, removeActiveClass } from './navigationBar.js';
 import fieldMapping from './fieldToConceptIdMapping.js'; 
 import { renderParticipantHeader } from './participantHeader.js';
 import { getCurrentTimeStamp, getDataAttributes } from './utils.js';
-import {renderParticipantSummary} from './participantSummary.js'
+import { renderParticipantSummary } from './participantSummary.js';
+import { renderLookupResultsTable } from './participantLookup.js';
 
 export const importantColumns = [ 
 
@@ -118,6 +119,7 @@ export const renderParticipantDetails = (participant, adminSubjectAudit, changed
     changeParticipantDetail(participant, adminSubjectAudit, changedOption, originalHTML, siteKey);
     editAltContact(participant, adminSubjectAudit);
     viewParticipantSummary(participant);
+    renderReturnSearchResults();
   
 }
 
@@ -137,6 +139,9 @@ export const render = (participant) => {
                     <div id="alert_placeholder"></div>`
         template += renderParticipantHeader(participant);
         template += `
+                    <div class="float-left">
+                        <button type="button" class="btn btn-primary" id="displaySearchResultsBtn">Back to Search</button>
+                    </div>
                     <table class="table detailsTable"> <h4 style="text-align: center;"> Participant Details </h4>
                         <thead style="position: sticky;" class="thead-dark"> 
                         <tr>
@@ -600,3 +605,11 @@ const viewParticipantSummary = (participant) => {
         })
     }
 }
+
+const renderReturnSearchResults = () => {
+    const a = document.getElementById('displaySearchResultsBtn');
+    if (a) {
+        a.addEventListener('click', () => {
+            renderLookupResultsTable();
+        })
+}}

--- a/siteManagerDashboard/participantLookup.js
+++ b/siteManagerDashboard/participantLookup.js
@@ -1,5 +1,5 @@
-import {renderNavBarLinks, dashboardNavBarLinks, renderLogin, removeActiveClass} from './navigationBar.js';
-import {renderTable, filterdata, filterBySiteKey, renderData, importantColumns, addEventFilterData, activeColumns, eventVerifiedButton} from './participantCommons.js';
+import { renderNavBarLinks, dashboardNavBarLinks, renderLogin, removeActiveClass } from './navigationBar.js';
+import { renderTable, filterdata, filterBySiteKey, renderData, importantColumns, addEventFilterData, activeColumns, eventVerifiedButton } from './participantCommons.js';
 import { internalNavigatorHandler, getDataAttributes } from './utils.js';
 import { nameToKeyObj } from './siteKeysToName.js';
 
@@ -188,6 +188,7 @@ export const performSearch = async (query, sitePref, failedElem) => {
                 return alertTrigger();
             }
         }
+        localStorage.setItem('filterRawData', JSON.stringify(filterRawData))
         mainContent.innerHTML = renderTable(filterRawData, 'participantLookup');
         addEventFilterData(filterRawData);
         renderData(filterRawData);
@@ -233,4 +234,16 @@ const renderLookupSiteDropdown = () => {
     let dropDownstatusFlag = localStorage.getItem('dropDownstatusFlag');
     if (dropDownstatusFlag === 'true') {
         document.getElementById("siteDropdownLookup").hidden = false }
+}
+
+export const renderLookupResultsTable = () => {
+    let filterRawData = JSON.parse(localStorage.getItem('filterRawData'));
+    mainContent.innerHTML = renderTable(filterRawData, 'participantLookup');
+    addEventFilterData(filterRawData);
+    renderData(filterRawData);
+    activeColumns(filterRawData);
+    const element = document.getElementById('back-to-search');
+    element.addEventListener('click', () => { 
+        renderParticipantLookup();
+    });
 }


### PR DESCRIPTION
This PR addresses the following feature:
-> Address #42 feature request
-> User can go back to search results on Participant Lookup from Participant Details upon clicking Back to Search button
on Participant Details

Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [x] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added
- [x] Attach PoC
- [ ] Notes added

Test case 1:
Search for users with same first name, select one of them from participant lookup. Then on Participant Details,
click Back to Search button on left. Upon clicking, should display Participant Lookup result table.

<img width="1792" alt="Screen Shot 2021-04-14 at 2 43 29 PM" src="https://user-images.githubusercontent.com/30497847/114762458-c8a1c200-9d2f-11eb-99f3-c79eb2160eac.png">
<img width="1215" alt="Screen Shot 2021-04-14 at 2 43 41 PM" src="https://user-images.githubusercontent.com/30497847/114762481-cfc8d000-9d2f-11eb-82c7-1d8366bdecbf.png">
<img width="1792" alt="Screen Shot 2021-04-14 at 2 43 53 PM" src="https://user-images.githubusercontent.com/30497847/114762507-d7887480-9d2f-11eb-9e1c-b9ccd31c0f5c.png">



