### PR TITLE
Site Manger Dashboard: Filtered out column buttons that return json response & duplicate columns

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -168,6 +168,9 @@ export default
     
     'active': 486306141,
     'passive': 854703046,
+    'recruitmentDate': 471593703,
+
+    'signinDate': 335767902
 
     // "D_726699695" : "Module1",
     // "D_745268907" : "Module2",

--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -2,7 +2,8 @@ import { renderParticipantDetails } from './participantDetails.js';
 import { animation, participantVerification } from './index.js'
 import fieldMapping from './fieldToConceptIdMapping.js'; 
 import { keyToNameObj } from './siteKeysToName.js';
-export const importantColumns = [fieldMapping.fName, fieldMapping.mName, fieldMapping.lName, fieldMapping.birthMonth, fieldMapping.birthDay, fieldMapping.birthYear, fieldMapping.prefEmail, 'Connect_ID', fieldMapping.healthcareProvider];
+export const importantColumns = [fieldMapping.fName, fieldMapping.mName, fieldMapping.lName, fieldMapping.birthMonth, fieldMapping.birthDay, fieldMapping.birthYear, fieldMapping.email, 'Connect_ID', fieldMapping.healthcareProvider];
+import { humanReadableMDYwithTime } from './utils.js';
 
 export const renderTable = (data, source) => {
     let template = '';
@@ -12,6 +13,12 @@ export const renderTable = (data, source) => {
         array = array.concat(Object.keys(dt))
     });
     array = array.filter((item, index) => array.indexOf(item) === index);
+    array = array.filter( i => 
+        (i !== '142654897' && i !== '266600170' && i !== '303552867' && i !== '452166062' && i !== '471168198'
+            && i !== '496823485' && i !== '650465111' && i !== '996038075' && i !== '8272206437' && i !== 'state' 
+            && i !== 'D_965707586' && i !== 'D_716117818' && i !== 'query' && i !== 'D_726699695' && i !== 'D_716117817' 
+            && i !== 'D_745268907' && i !== '506826178' && i !== 'Questionnaire' && i !== 'state.875549268' && i!== 'pin'
+            && i !== '436680969' && i !== '827220437' && i !== '231676651' && i !== '399159511' && i !== '736251808') )  // filter out columns with json response & duplicate columms 
     localStorage.removeItem("participant");
     let conceptIdMapping = JSON.parse(localStorage.getItem('conceptIdMapping'));
     
@@ -151,6 +158,7 @@ const tableTemplate = (data, showButtons) => {
         </tr>
     </thead>`;
     data.forEach(participant => {
+        // mapping from concept id to variable name
         template += `<tbody><tr><td><button class="btn btn-primary select-participant" data-token="${participant.token}">Select</button></td>`
         importantColumns.forEach(x => {
             if(participant[x] && typeof participant[x] === 'object'){
@@ -158,6 +166,41 @@ const tableTemplate = (data, showButtons) => {
             }
             else if ( keyToNameObj[participant[x]] && keyToNameObj[participant[x]] !== undefined && x === fieldMapping.healthcareProvider ) {
                 template += `<td>${keyToNameObj[participant[x]] ? keyToNameObj[participant[x]] : ''}</td>`
+            }
+            else if (participant[x] && participant[x] === fieldMapping.no) {
+                template += `<td>${participant[x] ? 'No' : ''}</td>`
+            }
+            else if (participant[x] && participant[x] === fieldMapping.yes) {
+                template += `<td>${participant[x] ? 'Yes' : ''}</td>`
+            }
+            else if (participant[x] && participant[x] === fieldMapping.active) {
+                template += `<td>${participant[x] ? 'Active' : ''}</td>`
+            }
+            else if (participant[x] && participant[x] === fieldMapping.passive) {
+                template += `<td>${participant[x] ? 'Passive' : ''}</td>`
+            }
+            else if (participant[x] && participant[x] === fieldMapping.prefPhone) {
+                template += `<td>${participant[x] ? 'Text Message' : ''}</td>`
+            }
+            else if (participant[x] && participant[x] === fieldMapping.prefEmail) {
+                template += `<td>${participant[x] ? 'Email' : ''}</td>`
+            }
+            else if ((x === (fieldMapping.signinDate).toString()) || (x === (fieldMapping.userProfileDateTime).toString()) || (x === (fieldMapping.consentDate).toString())
+             || (x === (fieldMapping.recruitmentDate).toString()) || (x === (fieldMapping.verficationDate).toString())) {
+                template += `<td>${participant[x] ? humanReadableMDYwithTime(participant[x]) : ''}</td>` // human readable time date
+            }
+            else if (x === (fieldMapping.verifiedFlag).toString()) {
+                if (participant[x] === fieldMapping.notYetVerified) {
+                    template += `<td>${participant[x] ? 'Not Yet Verified'  : ''}</td>`
+                } else if (participant[x] === fieldMapping.outreachTimedout) {
+                    template += `<td>${participant[x] ? 'Out Reach Timed Out'  : ''}</td>`
+                } else if (participant[x] === fieldMapping.verified) {
+                    template += `<td>${participant[x] ? 'Verified'  : ''}</td>`
+                } else if (participant[x] === fieldMapping.cannotBeVerified) {
+                    template += `<td>${participant[x] ? 'Can Not Be Verified '  : ''}</td>`
+                } else {
+                    template += `<td>${participant[x] ? 'Duplicate'  : ''}</td>`
+                }
             }
             else {
                 template += `<td>${participant[x] ? participant[x] : ''}</td>`

--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -161,50 +161,40 @@ const tableTemplate = (data, showButtons) => {
         // mapping from concept id to variable name
         template += `<tbody><tr><td><button class="btn btn-primary select-participant" data-token="${participant.token}">Select</button></td>`
         importantColumns.forEach(x => {
-            if(participant[x] && typeof participant[x] === 'object'){
-                template += `<td><pre>${JSON.stringify(participant[x], undefined, 4)}</pre></td>`
-            }
-            else if ( keyToNameObj[participant[x]] && keyToNameObj[participant[x]] !== undefined && x === fieldMapping.healthcareProvider ) {
-                template += `<td>${keyToNameObj[participant[x]] ? keyToNameObj[participant[x]] : ''}</td>`
-            }
-            else if (participant[x] && participant[x] === fieldMapping.no) {
-                template += `<td>${participant[x] ? 'No' : ''}</td>`
-            }
-            else if (participant[x] && participant[x] === fieldMapping.yes) {
-                template += `<td>${participant[x] ? 'Yes' : ''}</td>`
-            }
-            else if (participant[x] && participant[x] === fieldMapping.active) {
-                template += `<td>${participant[x] ? 'Active' : ''}</td>`
-            }
-            else if (participant[x] && participant[x] === fieldMapping.passive) {
-                template += `<td>${participant[x] ? 'Passive' : ''}</td>`
-            }
-            else if (participant[x] && participant[x] === fieldMapping.prefPhone) {
-                template += `<td>${participant[x] ? 'Text Message' : ''}</td>`
-            }
-            else if (participant[x] && participant[x] === fieldMapping.prefEmail) {
-                template += `<td>${participant[x] ? 'Email' : ''}</td>`
-            }
-            else if ((x === (fieldMapping.signinDate).toString()) || (x === (fieldMapping.userProfileDateTime).toString()) || (x === (fieldMapping.consentDate).toString())
-             || (x === (fieldMapping.recruitmentDate).toString()) || (x === (fieldMapping.verficationDate).toString())) {
-                template += `<td>${participant[x] ? humanReadableMDYwithTime(participant[x]) : ''}</td>` // human readable time date
-            }
-            else if (x === (fieldMapping.verifiedFlag).toString()) {
-                if (participant[x] === fieldMapping.notYetVerified) {
+            (participant[x] && typeof participant[x] === 'object') ?
+                (template += `<td><pre>${JSON.stringify(participant[x], undefined, 4)}</pre></td>`)
+            : 
+            ( keyToNameObj[participant[x]] && keyToNameObj[participant[x]] !== undefined && x === fieldMapping.healthcareProvider ) ? 
+               ( template += `<td>${keyToNameObj[participant[x]] ? keyToNameObj[participant[x]] : ''}</td>`)
+            : (participant[x] && participant[x] === fieldMapping.no) ?
+               ( template += `<td>${participant[x] ? 'No' : ''}</td>` )
+            : (participant[x] && participant[x] === fieldMapping.yes) ?
+               ( template += `<td>${participant[x] ? 'Yes' : ''}</td>` )
+            : (participant[x] && participant[x] === fieldMapping.active) ?
+               ( template += `<td>${participant[x] ? 'Active' : ''}</td>` )
+            : (participant[x] && participant[x] === fieldMapping.passive) ?
+                ( template += `<td>${participant[x] ? 'Passive' : ''}</td>`)
+            : (participant[x] && participant[x] === fieldMapping.prefPhone) ?
+               ( template += `<td>${participant[x] ? 'Text Message' : ''}</td>` )
+            : (participant[x] && participant[x] === fieldMapping.prefEmail) ?
+               ( template += `<td>${participant[x] ? 'Email' : ''}</td>` )
+            : ((x === (fieldMapping.signinDate).toString()) || (x === (fieldMapping.userProfileDateTime).toString()) || (x === (fieldMapping.consentDate).toString())
+             || (x === (fieldMapping.recruitmentDate).toString()) || (x === (fieldMapping.verficationDate).toString())) ? 
+               ( template += `<td>${participant[x] ? humanReadableMDYwithTime(participant[x]) : ''}</td>`) // human readable time date
+            : (x === (fieldMapping.verifiedFlag).toString()) ?
+            (
+                (participant[x] === fieldMapping.notYetVerified) ?
                     template += `<td>${participant[x] ? 'Not Yet Verified'  : ''}</td>`
-                } else if (participant[x] === fieldMapping.outreachTimedout) {
+                : (participant[x] === fieldMapping.outreachTimedout) ?
                     template += `<td>${participant[x] ? 'Out Reach Timed Out'  : ''}</td>`
-                } else if (participant[x] === fieldMapping.verified) {
+                : (participant[x] === fieldMapping.verified) ?
                     template += `<td>${participant[x] ? 'Verified'  : ''}</td>`
-                } else if (participant[x] === fieldMapping.cannotBeVerified) {
+                : (participant[x] === fieldMapping.cannotBeVerified) ?
                     template += `<td>${participant[x] ? 'Can Not Be Verified '  : ''}</td>`
-                } else {
-                    template += `<td>${participant[x] ? 'Duplicate'  : ''}</td>`
-                }
-            }
-            else {
-                template += `<td>${participant[x] ? participant[x] : ''}</td>`
-            }
+                : (
+                    template += `<td>${participant[x] ? 'Duplicate'  : ''}</td>` )
+            )
+            : (template += `<td>${participant[x] ? participant[x] : ''}</td>`)
         })
         template += `<td><a data-toggle="modal" data-target="#modalShowMoreData" name="modalParticipantData" class="change-pointer showMoreInfo" data-token="${participant.token}"><i class="fas fa-info-circle"></i></a></td>
         ${showButtons ? `<td class="no-wrap"><button class="btn btn-primary participantVerified" data-token="${participant.token}"><i class="fas fa-user-check"></i> Verify</button> / <button class="btn btn-primary participantNotVerified" data-token="${participant.token}"><i class="fas fa-user-times"></i> Can't Verify</button></td>`: ``}


### PR DESCRIPTION
This PR addresses fix for following issue:
-> #43 
-> Filtered out column buttons that return json response & duplicate columns. Turned concept IDs to variable names and human readable time/date format

Checklist:
- [X] Code cleanup
- [X] Check for ES Lint warnings
- [X] Verify test cases
- [X] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added
- [X] Attach PoC
- [ ] Add notes

Test Cases Verified: 
- [x] Check if columns button participants works fine for 'All Participants', 'Not Yet Verified Participants', and 'Cannot be verified' page
**Not Verified Participants**
<img width="1770" alt="Screen Shot 2021-04-15 at 3 33 02 PM" src="https://user-images.githubusercontent.com/30497847/114927792-dfafe500-9dff-11eb-8f5d-3f437a8cc3bf.png">

**All Participants**
<img width="1765" alt="Screen Shot 2021-04-15 at 3 56 18 PM" src="https://user-images.githubusercontent.com/30497847/114930533-1fc49700-9e03-11eb-9812-83522d754885.png">


PoC:
**Filtered out columns**
<img width="1752" alt="Screen Shot 2021-04-15 at 3 29 39 PM" src="https://user-images.githubusercontent.com/30497847/114927393-6617f700-9dff-11eb-86c6-6fe52661e0ad.png">
<img width="1774" alt="Screen Shot 2021-04-15 at 3 27 36 PM" src="https://user-images.githubusercontent.com/30497847/114927102-1cc7a780-9dff-11eb-9b8f-c5b3ffd2b0bc.png">

**Signed In Status**
<img width="1758" alt="Screen Shot 2021-04-15 at 3 03 53 PM" src="https://user-images.githubusercontent.com/30497847/114926629-96ab6100-9dfe-11eb-848c-e4ac257e40df.png">
<img width="1758" alt="Screen Shot 2021-04-15 at 3 26 58 PM" src="https://user-images.githubusercontent.com/30497847/114927031-06b9e700-9dff-11eb-87b4-2819961f91ff.png">


**Verified Status**
<img width="1773" alt="Screen Shot 2021-04-15 at 3 04 03 PM" src="https://user-images.githubusercontent.com/30497847/114926648-9e6b0580-9dfe-11eb-9454-800166c968fb.png">
<img width="1760" alt="Screen Shot 2021-04-15 at 3 25 45 PM" src="https://user-images.githubusercontent.com/30497847/114926865-da9e6600-9dfe-11eb-8591-be788a908ee2.png">
