### PR TITLE
Participant withdrawal feedback

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -195,6 +195,7 @@ export default
     'tooSick': 431428747,
     'noInternet': 121430614,
     'worriedAboutResults': 523768810,
+    'dontLikeThingsOnline': 352891568,
     'concernedAboutResults': 639172801,
     'concernedAboutPrivacy': 175732191,
     'concernedAboutInformationOnline': 637147033,
@@ -208,7 +209,6 @@ export default
     'worriedAboutInformationMisue':  372303208,
     'worriedAboutOtherPrivacyConcerns': 777719027,
     'unableToCompleteOnlineActivites': 620696506,
-    'dontLikeThingsOnline': 352891568,
     'concernedAboutCovid': 958588520,
     'participantUnableToParticipate': 875010152,
     'participantIncarcerated': 404289911,
@@ -229,6 +229,7 @@ export default
     "3": 872012139,
     "4": 854021266,
     "5": 241236037,
+    "6": 987563196,
 
     "noRefusal": 208325815,
     "refusedSome": 622008261,	
@@ -236,11 +237,17 @@ export default
     "revokeHIPAA": 872012139,
     "withdrewConsent": 854021266,
     "destroyData": 241236037,
-    "deceased": 567870674
-            
+    "deceased": 987563196,
 
+    208325815 :  "No refusal",
+    622008261 : "Refused some activities",  
+    134659217 : "Refused all future activities",
+    872012139 : "Revoked HIPAA only",
+    854021266 : "Withdrew Consent",
+    241236037 :  "Destroy Data",
+    987563196 : "Deceased",
 
-    
+    'sourceOfDeath': 764403541
 
 
 

--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -73,8 +73,6 @@ export default
     "yes": 353358909,
     "no": 104430631,
 
-    "refusedSurvey": 994064239,
-
     "biospecimenFlag": 650516960,
     "biospecimenResearch": 534621077,
     "biospecimenClinical": 664882224,
@@ -172,6 +170,64 @@ export default
     'inactive': 180583933,
     'recruitmentDate': 471593703,
 
-    'signinDate': 335767902
+    'signinDate': 335767902,
+
+    'refusalOptions': 685002411,
+
+    'refusedSurvey': 994064239,
+    // 'refusedBloodSample': 194410742,
+    // 'refusedUrineSample': 949501163,
+    // 'refusedMouthwashSample': 277479354,
+    'refusedSpecimenSurevys': 217367618,
+    'refusedSpecimenSurevys': 867203506,
+    'refusedFutureSamples': 352996056,
+    
+    'refusedAllFutureActivities': 906417725,
+    'revokeHIPAA': 773707518,
+    'withdrawConsent': 747006172,
+    'destroyData': 831041022,
+    'participantDeceased': 987563196,
+
+    'tooBusy': 851245875,
+    'noLongerInterested': 919699172,
+    'participantGreedy': 141450621,
+    'notGreatBenefit': 576083042,
+    'tooSick': 431428747,
+    'noInternet': 121430614,
+    'worriedAboutResults': 523768810,
+    'concernedAboutResults': 639172801,
+    'concernedAboutPrivacy': 175732191,
+    'concernedAboutInformationOnline': 637147033,
+    'doesntTrustGov': 150818546,
+    'doesntTrustResearch': 624030581,
+    'doesntWantInfoWithResearchers': 285488731,
+    'worriedAboutDataBreach': 596510649,
+    'worriedAboutInsurance': 866089092,
+    'worriedAboutEmployer': 990579614,
+    'worriedAboutDiscrimination': 131458944,
+    'worriedAboutInformationMisue':  372303208,
+    'worriedAboutOtherPrivacyConcerns': 777719027,
+    'unableToCompleteOnlineActivites': 620696506,
+    'dontLikeThingsOnline': 352891568,
+    'concernedAboutCovid': 958588520,
+    'participantUnableToParticipate': 875010152,
+    'participantIncarcerated': 404289911,
+    'otherReasons': 715390138,
+    'reasonNotGiven': 538619788,
+
+    'spouse': 817514412,
+    'child': 597175457,
+    'otherRelative': 341709648,
+    'ihcsStaff': 890182396,
+    'other': 181769837,
+
+    'participationStatus': 912301837
+
+
+    
+
+
+
+
 
 }

--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -221,7 +221,23 @@ export default
     'ihcsStaff': 890182396,
     'other': 181769837,
 
-    'participationStatus': 912301837
+    'participationStatus': 912301837,
+
+    "0": 208325815,
+    "1": 622008261,	
+    "2": 134659217,
+    "3": 872012139,
+    "4": 854021266,
+    "5": 241236037,
+
+    "noRefusal": 208325815,
+    "refusedSome": 622008261,	
+    "refusedAll": 134659217,
+    "revokeHIPAA": 872012139,
+    "withdrewConsent": 854021266,
+    "destroyData": 241236037,
+    "deceased": 567870674
+            
 
 
     

--- a/siteManagerDashboard/index.html
+++ b/siteManagerDashboard/index.html
@@ -9,6 +9,7 @@
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
         <link rel="stylesheet" href="assets/css/dashboard.css">
+        <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/pikaday/css/pikaday.css">
         
     </head>
     <body>
@@ -60,6 +61,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/downloadjs/1.4.8/download.js"></script>
         <script src="https://www.gstatic.com/firebasejs/7.14.2/firebase-app.js"></script>
         <script src="https://www.gstatic.com/firebasejs/7.14.2/firebase-auth.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/pikaday/pikaday.js"></script>
         <script type="module" src="index.js"></script>
     </body>
 </html>

--- a/siteManagerDashboard/index.js
+++ b/siteManagerDashboard/index.js
@@ -705,6 +705,7 @@ const renderParticipantsNotVerified = async () => {
         const localStr = JSON.parse(localStorage.dashboard);
         const siteKey = localStr.siteKey;
         const response = await fetchData(siteKey, 'notyetverified');
+        console
         response.data = response.data.sort((a, b) => (a['827220437'] > b['827220437']) ? 1 : ((b['827220437'] > a['827220437']) ? -1 : 0));
         if (response.code === 200) {
             document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks();

--- a/siteManagerDashboard/navigationBar.js
+++ b/siteManagerDashboard/navigationBar.js
@@ -16,7 +16,7 @@ export const renderNavBarLinks = () => {
     `;
 }
 
-export const dashboardNavBarLinks = () => {
+export const dashboardNavBarLinks = (isParent) => {
     return `
         <li class="nav-item">
             <a class="nav-item nav-link ws-nowrap" href="#dashboard" title="Dashboard" id="dashboardBtn"><i class="fas fa-home"></i> Dashboard</a>
@@ -41,9 +41,10 @@ export const dashboardNavBarLinks = () => {
         <li class="nav-item" id="participantSummaryBtn">
             <a class="nav-item nav-link ws-nowrap" href="#participantSummary" title="Participant Summary"><i class="fa fa-id-badge"></i> Participant Summary</a>
         </li>
-        <li class="nav-item" id="participantWithdrawalBtn">
-        <a class="nav-item nav-link ws-nowrap" href="#participantWithdrawal" title="Participant Withdrawal"><i class="fa fa-list-alt"></i> Participant Withdrawal</a>
-    </li>
+        ${isParent === 'true' ?
+        (`<li class="nav-item" id="participantWithdrawalBtn">
+            <a class="nav-item nav-link ws-nowrap" href="#participantWithdrawal" title="Participant Withdrawal"><i class="fa fa-list-alt"></i> Participant Withdrawal</a>
+        </li>`) : (``)  }
         <li class="nav-item">
             <a class="nav-item nav-link ws-nowrap" href="#logout" title="Log Out"><i class="fas fa-sign-out-alt"></i> Log Out</a>
         </li>

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -1,7 +1,7 @@
 import { renderNavBarLinks, dashboardNavBarLinks, removeActiveClass } from './navigationBar.js';
 import fieldMapping from './fieldToConceptIdMapping.js'; 
 import { renderParticipantHeader } from './participantHeader.js';
-import { getCurrentTimeStamp, getDataAttributes } from './utils.js';
+import { getCurrentTimeStamp, getDataAttributes, showAnimation, hideAnimation } from './utils.js';
 import { renderParticipantSummary } from './participantSummary.js';
 import { renderLookupResultsTable } from './participantLookup.js';
 
@@ -516,6 +516,7 @@ const postEditedResponse = (participant, adminSubjectAudit, changedOption, siteK
     a.addEventListener('click', () => {
         const participantToken = participant.token;
         changedOption['token'] = participantToken;
+        console.log('conol', changedOption)
         clickHandler(adminSubjectAudit, changedOption, siteKey);
     })
 }
@@ -555,17 +556,6 @@ async function clickHandler(adminSubjectAudit, updatedOptions, siteKey)  {
                (alert('Error'))
         }
  }
-
-
-// shows a spinner when HTTP request is made
-export const showAnimation = () => {
-    if(document.getElementById('loadingAnimation')) document.getElementById('loadingAnimation').style.display = '';
-}
-
-export const hideAnimation = () => {
-    if(document.getElementById('loadingAnimation')) document.getElementById('loadingAnimation').style.display = 'none';
-}
-
 
 // Admin audit displaying logs
  const viewAuditHandler = (adminSubjectAudit) => {

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -134,7 +134,6 @@ export const render = (participant) => {
         `
     } else {
         let conceptIdMapping = JSON.parse(localStorage.getItem('conceptIdMapping'));
-        console.log('conceptIdMapping', conceptIdMapping)
         template += `<div id="root" > 
                     <div id="alert_placeholder"></div>`
         template += renderParticipantHeader(participant);

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -108,8 +108,8 @@ window.addEventListener('onload', (e) => {
 
 
 export const renderParticipantDetails = (participant, adminSubjectAudit, changedOption, siteKey) => {
-
-    document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks();
+    const isParent = localStorage.getItem('isParent')
+    document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks(isParent);
     removeActiveClass('nav-link', 'active');
     document.getElementById('participantDetailsBtn').classList.add('active');
     mainContent.innerHTML = render(participant);

--- a/siteManagerDashboard/participantHeader.js
+++ b/siteManagerDashboard/participantHeader.js
@@ -1,4 +1,3 @@
-
 import fieldMapping from './fieldToConceptIdMapping.js';
 import { humanReadableMDY } from './utils.js';
 import { keyToNameObj } from './siteKeysToName.js';
@@ -12,7 +11,7 @@ export const headerImportantColumns = [
     { field: fieldMapping.verifiedFlag },
     { field: 'Site' },
     { field: 'Year(s) in Connect' },
-    { field: 'Status' }
+    { field: 'Participation Status'}
 ];
 
 
@@ -26,9 +25,9 @@ export const renderParticipantHeader = (participant) => {
         (headerImportantColumns[x].field === 'Connect_ID' ) ?
             template += `<span><b> ${headerImportantColumns[x].field} </b></span> : ${participant[headerImportantColumns[x].field] !== undefined ?  participant[headerImportantColumns[x].field] : ""} &nbsp;`
         :
-        
-        (headerImportantColumns[x].field === 'Status' ) ?
-            template += `<span><b> Status </b></span> : Active &nbsp;`
+
+        (headerImportantColumns[x].field === 'Participation Status' ) ?
+        template += `<span><b>Participation Status </b></span> : ${getParticipationStatus(participant)}  &nbsp;`
         :
 
         (headerImportantColumns[x].field === 'Year(s) in Connect' ) ?
@@ -106,4 +105,14 @@ const concatDOB = (participant) => {
 const renderSiteLocation = (participant) => {
     const siteHealthcareProvider = participant[fieldMapping.healthcareProvider];
     return keyToNameObj[siteHealthcareProvider];
+}
+
+export const getParticipationStatus = (participant) => {
+
+   if (typeof participant !== "string") {
+        const statusValue = participant[fieldMapping.participationStatus];
+        return fieldMapping[statusValue] }
+    {   
+        return participant
+    }
 }

--- a/siteManagerDashboard/participantLookup.js
+++ b/siteManagerDashboard/participantLookup.js
@@ -1,6 +1,6 @@
 import { renderNavBarLinks, dashboardNavBarLinks, renderLogin, removeActiveClass } from './navigationBar.js';
 import { renderTable, filterdata, filterBySiteKey, renderData, importantColumns, addEventFilterData, activeColumns, eventVerifiedButton } from './participantCommons.js';
-import { internalNavigatorHandler, getDataAttributes } from './utils.js';
+import { internalNavigatorHandler, getDataAttributes, showAnimation, hideAnimation } from './utils.js';
 import { nameToKeyObj } from './siteKeysToName.js';
 
 export function renderParticipantLookup(){
@@ -202,14 +202,6 @@ export const performSearch = async (query, sitePref, failedElem) => {
         document.getElementById(failedElem).hidden = false;
         alertTrigger();
     }
-}
-
-export const showAnimation = () => {
-    if(document.getElementById('loadingAnimation')) document.getElementById('loadingAnimation').style.display = '';
-}
-
-export const hideAnimation = () => {
-    if(document.getElementById('loadingAnimation')) document.getElementById('loadingAnimation').style.display = 'none';
 }
 
 export const showNotifications = (data, error) => {

--- a/siteManagerDashboard/participantLookup.js
+++ b/siteManagerDashboard/participantLookup.js
@@ -4,8 +4,8 @@ import { internalNavigatorHandler, getDataAttributes, getIdToken, showAnimation,
 import { nameToKeyObj } from './siteKeysToName.js';
 
 export function renderParticipantLookup(){
-
-    document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks();
+    const isParent = localStorage.getItem('isParent')
+    document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks(isParent);
     removeActiveClass('nav-link', 'active');
     document.getElementById('participantLookupBtn').classList.add('active');
     localStorage.removeItem("participant");
@@ -54,14 +54,14 @@ export function renderParticipantSearch() {
                             </div>
                             <div class="form-group dropdown" id="siteDropdownLookup" hidden>
                                 <label class="col-form-label search-label">Site Preference </label> &nbsp;
-                                <button class="btn btn-primary btn-lg" type="button" id="dropdownSites" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    Change Site Preference
+                                <button class="btn btn-primary btn-lg dropdown-toggle" type="button" id="dropdownSites" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                Filter by Site
                                 </button>
                                 <ul class="dropdown-menu" id="dropdownMenuLookupSites" aria-labelledby="dropdownMenuButton">
+                                    <li><a class="dropdown-item" data-siteKey="allResults" id="all">All</a></li>
                                     <li><a class="dropdown-item" data-siteKey="hfHealth" id="hfHealth">Henry Ford Health Systems</a></li>
                                     <li><a class="dropdown-item" data-siteKey="hPartners" id="hPartners">Health Partners</a></li>
                                     <li><a class="dropdown-item" data-siteKey="kpGA" id="kpGA">KP GA</a></li>
-                                    <li><a class="dropdown-item" data-siteKey="kpHI" id="kpHI">KP HI</a></li>
                                     <li><a class="dropdown-item" data-siteKey="kpHI" id="kpHI">KP HI</a></li>
                                     <li><a class="dropdown-item" data-siteKey="kpNW" id="kpNW">KP NW</a></li>
                                     <li><a class="dropdown-item" data-siteKey="kpCO" id="kpCO">KP CO</a></li>

--- a/siteManagerDashboard/participantSummary.js
+++ b/siteManagerDashboard/participantSummary.js
@@ -16,8 +16,8 @@ const { PDFDocument, StandardFonts } = PDFLib
 document.body.scrollTop = document.documentElement.scrollTop = 0;
 
 export const renderParticipantSummary = (participant) => {
-
-    document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks();
+    const isParent = localStorage.getItem('isParent')
+    document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks(isParent);
     removeActiveClass('nav-link', 'active');
     document.getElementById('participantSummaryBtn').classList.add('active');
     if (participant !== null) {

--- a/siteManagerDashboard/participantSummary.js
+++ b/siteManagerDashboard/participantSummary.js
@@ -188,7 +188,7 @@ const consentHandler = (participant) => {
                     <td>Signed</td>
                     <td>${participant[fieldMapping.consentDate] && humanReadableMDY(participant[fieldMapping.consentDate])}</td>
                     <td>${participant[fieldMapping.consentVersion]}</td>
-                    <td>N/A</td>
+                    <td>N</td>
                     <td><a style="color: blue; text-decoration: underline;" target="_blank" id="downloadCopy">Download Link</a></td>
     ` ) : 
     (
@@ -199,7 +199,7 @@ const consentHandler = (participant) => {
                     <td>Not Signed</td>
                     <td>N/A</td>
                     <td>N/A</td>
-                    <td>Y</td>
+                    <td>N</td>
                     <td style="color: grey; text-decoration: underline;">Download Link</td>`
     )
     return template;
@@ -218,7 +218,7 @@ const hippaHandler = (participant) => {
                     <td>Signed</td>
                     <td>${participant[fieldMapping.hippaDate] && humanReadableMDY(participant[fieldMapping.hippaDate])}</td>
                     <td>${participant[fieldMapping.hippaVersion]}</td>
-                    <td>N/A</td>
+                    <td>N</td>
                     <td style="color: grey; text-decoration: underline;">Download Link</td>
     ` ) : 
     (
@@ -229,7 +229,7 @@ const hippaHandler = (participant) => {
                     <td>Not Signed</td>
                     <td>N/A</td>
                     <td>N/A</td>
-                    <td>N/A</td>
+                    <td>N</td>
                     <td style="color: grey; text-decoration: underline;">Download Link</td>`
     )
     return template;

--- a/siteManagerDashboard/participantSummaryRow.js
+++ b/siteManagerDashboard/participantSummaryRow.js
@@ -6,7 +6,7 @@ export const userProfile = (participant) => {
     let template = ``;
     !participant ?
     (template += `
-            ${getTemplateRow("fa fa-times fa-2x", "color: red", "Enrollment", "N/A", "User Profile", "N/A", "N/A", "N/A", "N/A", "N/A")}
+            ${getTemplateRow("fa fa-times fa-2x", "color: red", "Enrollment", "N/A", "User Profile", "N/A", "N/A", "N/A", "N", "N/A")}
     `)
     :
     (participant[fieldMapping.userProfileFlag] === (fieldMapping.yes) ?
@@ -30,7 +30,7 @@ export const verificationStatus = (participant) => {
     let template = ``;
     !participant ?
     (template += `
-        ${getTemplateRow("fa fa-times fa-2x", "color: red", "Enrollment", "N/A", "Verification", "N/A", "N/A", "N/A", "N/A", "N/A")}
+        ${getTemplateRow("fa fa-times fa-2x", "color: red", "Enrollment", "N/A", "Verification", "N/A", "N/A", "N/A", "N", "N/A")}
     `)
     : (
     (participant[fieldMapping.verifiedFlag] === fieldMapping.verified) ?
@@ -69,7 +69,7 @@ export const baselineBloodSample = (participantModule) => {
     !participantModule[fieldMapping.bloodFlag] ?  
     (
         template += `
-                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Sample", "Blood", "Not Collected", "N/A", "N/A", "N/A", "N/A")}
+                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Sample", "Blood", "Not Collected", "N/A", "N/A", "N", "N/A")}
             `
     ) : 
     participantModule[fieldMapping.refusedBlood] === (fieldMapping.yes) ?
@@ -98,7 +98,7 @@ export const baselineUrineSample = (participantModule) => {
     !participantModule[fieldMapping.urineFlag] ?  
     (
         template += `
-                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Sample", "Urine", "Not Collected", "N/A", "N/A", "N/A", "N/A")}`
+                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Sample", "Urine", "Not Collected", "N/A", "N/A", "N", "N/A")}`
     ) : 
     participantModule[fieldMapping.refusedUrine] === (fieldMapping.yes) ?
     (
@@ -125,7 +125,7 @@ export const baselineMouthwashSample = (participantModule) => {
     !participantModule[fieldMapping.mouthwash] ?  
     (
         template += `
-                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Sample", "Mouthwash", "Not Collected", "N/A", "N/A", "N/A", "N/A")}`
+                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Sample", "Mouthwash", "Not Collected", "N/A", "N/A", "N", "N/A")}`
     ) : 
     participantModule[fieldMapping.refusedMouthwash] === (fieldMapping.yes) ?
     (
@@ -150,7 +150,7 @@ export const baselineBOHSurvey = (participantModule) => {
     !participantModule ?  
     (
         template += `
-            ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "BOH", "N/A", "N/A", "N/A", "N/A", "N/A")}`
+            ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "BOH", "N/A", "N/A", "N/A", "N", "N/A")}`
     ) : 
     participantModule[fieldMapping.refusedSurvey] === (fieldMapping.yes) ?
     (
@@ -184,7 +184,7 @@ export const baselineMRESurvey = (participantModule) => {
     !participantModule ?  
     (
         template += `
-                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "MRE", "N/A", "N/A", "N/A", "N/A", "N/A")}`
+                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "MRE", "N/A", "N/A", "N/A", "N", "N/A")}`
     ) : 
     participantModule[fieldMapping.refusedSurvey] === (fieldMapping.yes) ?
     (
@@ -217,7 +217,7 @@ export const baselineSASSurvey = (participantModule) => {
     !participantModule ?  
     (
         template += `
-                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "SAS", "N/A", "N/A", "N/A", "N/A", "N/A")}`
+                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "SAS", "N/A", "N/A", "N/A", "N", "N/A")}`
     ) : 
     participantModule[fieldMapping.refusedSurvey] === (fieldMapping.yes) ?
     (
@@ -250,7 +250,7 @@ export const baselineLAWSurvey = (participantModule) => {
     !participantModule ?  
     (
         template += `
-                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "LAW", "N/A", "N/A", "N/A", "N/A", "N/A")}`
+                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "LAW", "N/A", "N/A", "N/A", "N", "N/A")}`
     ) : 
     participantModule[fieldMapping.refusedSurvey] === (fieldMapping.yes) ?
     (
@@ -283,18 +283,18 @@ export const baselineSSN = (participantModule) => {
         !participantModule ?  
         (
         template += `
-            ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "SSN", "None", "N/A", "N/A", "N/A", "N/A")}`
+            ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "SSN", "None", "N/A", "N/A", "N", "N/A")}`
         ) : 
         (
             (participantModule[fieldMapping.ssnFullflag]) ?
             (
             template += `
                     ${getTemplateRow("fa fa-check fa-2x", "color: green", "Baseline", "Survey", "SSN", "All Digits", 
-                    humanReadableMDY(participantModule[fieldMapping.ssnFulldate]), "N/A", "N/A", "N/A")}`
+                    humanReadableMDY(participantModule[fieldMapping.ssnFulldate]), "N/A", "N", "N/A")}`
             ) : 
             ( template += `
                 ${getTemplateRow("fa fa-hashtag fa-2x", "color: orange", "Baseline", "Survey", "SSN", "4 Digits", 
-                humanReadableMDY(participantModule[fieldMapping.ssnPartialDate]), "N/A", "N/A", "N/A")}`
+                humanReadableMDY(participantModule[fieldMapping.ssnPartialDate]), "N/A", "N", "N/A")}`
             ))
     return template;
 }
@@ -304,7 +304,7 @@ export const baselineBloodUrineSurvey = (participantModule) => {
     !participantModule ?  
     (
         template += `
-                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "Blood/Urine", "N/A", "N/A", "N/A", "N/A", "N/A")}`
+                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "Blood/Urine", "N/A", "N/A", "N/A", "N", "N/A")}`
     ) : 
     participantModule[fieldMapping.refusedSurvey] === (fieldMapping.yes) ?
     (
@@ -337,7 +337,7 @@ export const baselineMouthwashSurvey = (participantModule) => {
     !participantModule ?  
     (
         template += `
-                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "Mouthwash", "N/A", "N/A", "N/A", "N/A", "N/A")}`
+                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Survey", "Mouthwash", "N/A", "N/A", "N/A", "N", "N/A")}`
     ) : 
     participantModule[fieldMapping.refusedSurvey] === (fieldMapping.yes) ?
     (
@@ -372,7 +372,7 @@ export const baselineEMR = (participantModule) => {
     !(participantModule) ?  
     (
         template += `
-                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "EMR", "N/A", "Not Pushed", "N/A", "N/A", "N/A", "N/A")}`
+                ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "EMR", "N/A", "Not Pushed", "N/A", "N/A", "N", "N/A")}`
     ) : 
     (participantModule[fieldMapping.baselineEMRflag]) === (fieldMapping.yes) ?  
     (
@@ -393,7 +393,7 @@ export const baselinePayment = (participantModule) => {
     !participantModule ?  
     (
         template += `
-                 ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Payment", "N/A", "N/A", "N/A", "N/A", "N/A", "N/A")}
+                 ${getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Payment", "N/A", "N/A", "N/A", "N/A", "N", "N/A")}
                 `
     ) : 
     participantModule[fieldMapping.refusedBaselinePayment] === (fieldMapping.yes) ?

--- a/siteManagerDashboard/participantWithdrawal.js
+++ b/siteManagerDashboard/participantWithdrawal.js
@@ -4,7 +4,8 @@ import { renderParticipantWithdrawalLandingPage, viewOptionsSelected, proceedToN
 
 
 export const renderParticipantWithdrawal = (participant) => {
-    document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks();
+    const isParent = localStorage.getItem('isParent')
+    document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks(isParent);
     removeActiveClass('nav-link', 'active');
     document.getElementById('participantWithdrawalBtn').classList.add('active');
     mainContent.innerHTML = render(participant);

--- a/siteManagerDashboard/participantWithdrawal.js
+++ b/siteManagerDashboard/participantWithdrawal.js
@@ -28,7 +28,7 @@ export const render = (participant) => {
                 <div id="root root-margin"> `
         template += renderParticipantHeader(participant);
         template += `<div id="formMainPage">
-                    ${renderParticipantWithdrawalLandingPage()}
+                    ${renderParticipantWithdrawalLandingPage(participant)}
                     </div></div>`
 }
 return template;

--- a/siteManagerDashboard/participantWithdrawalForm.js
+++ b/siteManagerDashboard/participantWithdrawalForm.js
@@ -1,6 +1,6 @@
 import fieldMapping from './fieldToConceptIdMapping.js';
 import { showAnimation, hideAnimation } from './utils.js';
-
+import { getParticipationStatus } from './participantHeader.js';
 
 export const renderParticipantWithdrawalLandingPage = (participant) => {
     localStorage.setItem('token', participant.token)
@@ -102,7 +102,7 @@ export const renderParticipantWithdrawalLandingPage = (participant) => {
                                 &nbsp;
                   ${participant[fieldMapping.participationStatus] === fieldMapping.noRefusal ?
                                 (`<button type="button" data-toggle="modal" data-target="#modalShowSelectedData"
-                                    class="btn btn-primary next-btn" id="nextFormPage" style="margin-top:20px;">Next</button>`)
+                                    class="btn btn-primary next-btn" id="nextFormPage" style="margin-top:40px;">Next</button>`)
                                     : 
                                 (`<button type="button" class="btn btn-secondary" disabled>Next</button>`)
                     }    
@@ -146,7 +146,6 @@ export const autoSelectOptions = () => {
     if (b) {
         b.addEventListener('change', function() {
             let checkedValue1 = document.getElementById('defaultCheck9');
-            console.log('checkedValue1', checkedValue1)
             checkedValue1.checked = true;
           });
     }
@@ -207,7 +206,7 @@ const retainPreviouslySetOptions = (retainOptions) => {
 }
 
 export const reasonForRefusalPage = (retainOptions) => {
-
+    let source = 'page1'
     let renderContent = document.getElementById('formMainPage');
     let template = ``;
     template += ` <div class="modal fade" id="modalShowFinalSelectedData" data-keyboard="false" tabindex="-1" role="dialog" data-backdrop="static" aria-hidden="true">
@@ -279,7 +278,8 @@ export const reasonForRefusalPage = (retainOptions) => {
                     </div>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I don’t like to do things online" name="options" id="defaultCheck">
+                        <input class="form-check-input" type="checkbox" value="I don’t like to do things online" name="options" 
+                        data-optionKey=${fieldMapping.dontLikeThingsOnline} id="defaultCheck">
                         <label class="form-check-label" for="defaultCheck">
                             I don’t like to do things online
                         </label>
@@ -405,12 +405,13 @@ export const reasonForRefusalPage = (retainOptions) => {
         proceedToNextPage();
     })
     document.getElementById('submit').addEventListener('click', () => {
-        collectFinalResponse(retainOptions)
+        collectFinalResponse(retainOptions, source)
     })
  
 }
 
 export const causeOfDeathPage = (retainOptions) => {
+    let source = 'page2'
     let renderContent = document.getElementById('formMainPage');
     let template = ``;
     template += ` <div class="modal fade" id="modalShowFinalSelectedData" data-keyboard="false" tabindex="-1" role="dialog" data-backdrop="static" aria-hidden="true">
@@ -476,21 +477,21 @@ export const causeOfDeathPage = (retainOptions) => {
         proceedToNextPage();
     })
     document.getElementById('submit').addEventListener('click', () => {
-        collectFinalResponse(retainOptions)
+        collectFinalResponse(retainOptions, source)
     })
  
 }
 
-const collectFinalResponse = (retainOptions) => {
+const collectFinalResponse = (retainOptions, source) => {
     let finalOptions = []
     let checkboxes = document.getElementsByName('options');
     checkboxes.forEach(x => { if (x.checked) {  
         finalOptions.push(x)}
     })
-    sendResponses(finalOptions, retainOptions);
+    sendResponses(finalOptions, retainOptions, source);
 }
 
-const sendResponses = (finalOptions, retainOptions) => {
+const sendResponses = (finalOptions, retainOptions, source) => {
     let sendRefusalData = {};
     let highestStatus = [];
     sendRefusalData[fieldMapping.refusalOptions] = {};
@@ -509,9 +510,13 @@ const sendResponses = (finalOptions, retainOptions) => {
                 sendRefusalData[x.dataset.optionkey] = fieldMapping.yes
             }
     })
+    source === 'page2' ? (
+        finalOptions.forEach(x => {
+            sendRefusalData[fieldMapping.sourceOfDeath] = parseInt(x.dataset.optionkey) })
+    ) : (
     finalOptions.forEach(x => {
         sendRefusalData[x.dataset.optionkey] = fieldMapping.yes
-    })
+    }))
     retainOptions.forEach(x => {
         switch (x.value) {
             case "Refusing all future activities":
@@ -538,7 +543,7 @@ const sendResponses = (finalOptions, retainOptions) => {
     sendRefusalData[fieldMapping.participationStatus] = fieldMapping[participationStatusScore.toString()];
     let refusalObj = sendRefusalData[fieldMapping.refusalOptions]
     if (JSON.stringify(refusalObj) === '{}') delete sendRefusalData[fieldMapping.refusalOptions]
-
+    getParticipationStatus(fieldMapping[fieldMapping[participationStatusScore.toString()]])
     const token = localStorage.getItem("token");
     sendRefusalData['token'] = token;
     console.log('sendRefusalData', sendRefusalData)

--- a/siteManagerDashboard/participantWithdrawalForm.js
+++ b/siteManagerDashboard/participantWithdrawalForm.js
@@ -1,6 +1,7 @@
 import fieldMapping from './fieldToConceptIdMapping.js';
 
 export const renderParticipantWithdrawalLandingPage = () => {
+    console.log( localStorage.getItem('participationStatus'))
     let template = ``;
     template = `        
                 <div class="row">
@@ -13,81 +14,96 @@ export const renderParticipantWithdrawalLandingPage = () => {
                                 <div style="position:relative; left:80px; top:2px;">
                                     <div class="form-check">
                                         <input class="form-check-input" name="options" type="checkbox" value="Baseline survey​" 
-                                        optionKey=${fieldMapping.refusedSurvey} id="defaultCheck1">
+                                        data-optionKey=${fieldMapping.refusedSurvey} id="defaultCheck1">
                                         <label class="form-check-label" for="defaultCheck1">
                                             Baseline survey​
                                         </label>
                                     </div>
                                     <div class="form-check">
-                                        <input class="form-check-input" name="options" type="checkbox" value="Baseline blood collection" id="defaultCheck2">
+                                        <input class="form-check-input" name="options" type="checkbox" value="Baseline blood collection" 
+                                        data-optionKey=${fieldMapping.refusedBlood} id="defaultCheck2">
                                         <label class="form-check-label" for="defaultCheck2">
                                             Baseline blood collection​
                                         </label>
                                     </div>
                                     <div class="form-check">
-                                        <input class="form-check-input" name="options" type="checkbox" value="Baseline urine collection" id="defaultCheck3">
+                                        <input class="form-check-input" name="options" type="checkbox" value="Baseline urine collection" 
+                                        data-optionKey=${fieldMapping.refusedUrine} id="defaultCheck3">
                                         <label class="form-check-label" for="defaultCheck3">
                                             Baseline urine collection​
                                         </label>
                                     </div>
                                     <div class="form-check">
-                                        <input class="form-check-input" name="options" type="checkbox" value="Baseline mouthwash collection​" id="defaultCheck4">
+                                        <input class="form-check-input" name="options" type="checkbox" value="Baseline mouthwash collection​" 
+                                        data-optionKey=${fieldMapping.refusedMouthwash} id="defaultCheck4">
                                         <label class="form-check-label" for="defaultCheck4">
                                             Baseline mouthwash collection​
                                         </label>
                                     </div>
                                     <div class="form-check">
-                                        <input class="form-check-input" name="options" type="checkbox" value="Baseline specimen surveys" id="defaultCheck5">
+                                        <input class="form-check-input" name="options" type="checkbox" value="Baseline specimen surveys" 
+                                        data-optionKey=${fieldMapping.refusedSpecimenSurevys} id="defaultCheck5">
                                         <label class="form-check-label" for="defaultCheck5">
                                             Baseline specimen surveys
                                         </label>
                                     </div>
                                     <div class="form-check">
-                                        <input class="form-check-input" name="options" type="checkbox" value="All future surveys (willing to do specimens)" id="defaultCheck6">
+                                        <input class="form-check-input" name="options" type="checkbox" value="All future surveys (willing to do specimens)" 
+                                        data-optionKey=${fieldMapping.refusedFutureSurveys} id="defaultCheck6">
                                         <label class="form-check-label" for="defaultCheck6">
                                             All future surveys (willing to do specimens)​
                                         </label>
                                     </div>
                                     <div class="form-check">
-                                        <input class="form-check-input" name="options" type="checkbox" value="All future specimens (willing to do surveys)" id="defaultCheck7">
+                                        <input class="form-check-input" name="options" type="checkbox" value="All future specimens (willing to do surveys)" 
+                                        data-optionKey=${fieldMapping.refusedFutureSamples} id="defaultCheck7">
                                         <label class="form-check-label" for="defaultCheck7">
                                             All future specimens (willing to do surveys)
                                         </label>
                                     </div>
                                 </div>
                                 <div class="form-check">
-                                    <input class="form-check-input" name="options" type="checkbox" value="Refusing all future activities" id="defaultCheck8">
+                                    <input class="form-check-input" name="options" type="checkbox" value="Refusing all future activities" 
+                                    data-optionKey=${fieldMapping.refusedAllFutureActivities} id="defaultCheck8">
                                     <label class="form-check-label" for="defaultCheck8">
                                         Refusing all future activities​
                                     </label>
                                 </div>
                                 <div class="form-check">
-                                    <input class="form-check-input" name="options" type="checkbox" value="Revoke HIPAA authorization (no medical records)*​" id="defaultCheck9">
+                                    <input class="form-check-input" name="options" type="checkbox" value="Revoke HIPAA authorization (no medical records)*​" 
+                                    data-optionKey=${fieldMapping.revokeHIPAA} id="defaultCheck9">
                                     <label class="form-check-label" for="defaultCheck9">
                                         Revoke HIPAA authorization (no medical records)*​
                                     </label>
                                 </div>
                                 <div class="form-check">
-                                    <input class="form-check-input" name="options" type="checkbox" value="Withdraw consent*​" id="defaultCheck10">
+                                    <input class="form-check-input" name="options" type="checkbox" value="Withdraw consent*​" 
+                                    data-optionKey=${fieldMapping.withdrawConsent} id="defaultCheck10">
                                     <label class="form-check-label" for="defaultCheck10">
                                         Withdraw consent*​
                                     </label>
                                 </div>
                                 <div class="form-check">
-                                    <input class="form-check-input" name="options" type="checkbox" value="Destroy data*​" id="defaultCheck11">
+                                    <input class="form-check-input" name="options" type="checkbox" value="Destroy data*​" 
+                                    data-optionKey=${fieldMapping.destroyData} id="defaultCheck11">
                                     <label class="form-check-label" for="defaultCheck11">
                                             Destroy data*​
                                     </label>
                                 </div>
                                 <div class="form-check">
-                                    <input class="form-check-input" name="options" id = "messageCheckbox" type="checkbox" value="Participant Deceased">
+                                    <input class="form-check-input" name="options" id = "messageCheckbox" type="checkbox" 
+                                    data-optionKey=${fieldMapping.participantDeceased} value="Participant Deceased">
                                     <label class="form-check-label" for="defaultCheck12">
                                         Participant Deceased
                                     </label>
                                 </div>
                                 &nbsp;
-                                    <button type="button" data-toggle="modal" data-target="#modalShowSelectedData"
-                                    class="btn btn-primary next-btn" id="nextFormPage" style="margin-top:20px;">Next</button>
+                                ${(localStorage.getItem('participationStatus') !== '0') ? 
+                                (`<button type="button" class="btn btn-primary next-btn" id="nextFormPage" style="margin-top:20px;" disabled>Next</button>`)
+                                    :
+                                    (`<button type="button" data-toggle="modal" data-target="#modalShowSelectedData"
+                                    class="btn btn-primary next-btn" id="nextFormPage" style="margin-top:20px;">Next</button>`) 
+                                   }
                                 </div>
                         </div>
                     </div>
@@ -109,7 +125,6 @@ export const renderParticipantWithdrawalLandingPage = () => {
             </div>
         </div>
     </div>`
-
     return template;
 
 }
@@ -117,14 +132,20 @@ export const renderParticipantWithdrawalLandingPage = () => {
 
 export const autoSelectOptions = () => {
     const a = document.getElementById('defaultCheck11');
+    const b = document.getElementById('defaultCheck10');
     if (a) {
         a.addEventListener('change', function() {
             let checkedValue = document.getElementById('defaultCheck10');
             checkedValue.checked = true;
             let checkedValue1 = document.getElementById('defaultCheck9');
             checkedValue1.checked = true;
-            let checkedValue2 = document.getElementById('defaultCheck8');
-            checkedValue2.checked = true;
+          });
+    }
+    if (b) {
+        b.addEventListener('change', function() {
+            let checkedValue1 = document.getElementById('defaultCheck9');
+            console.log('checkedValue1', checkedValue1)
+            checkedValue1.checked = true;
           });
     }
 }
@@ -139,23 +160,21 @@ export const viewOptionsSelected = () => {
 }
 
 const optionsHandler = () => {
-    let holdOptions = []
+    let retainOptions = []
     const header = document.getElementById('modalHeader');
     const body = document.getElementById('modalBody');
     let checkboxes = document.getElementsByName('options');
     header.innerHTML = `<h5>Options Selected</h5><button type="button" id="closeModal" class="modal-close-btn" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
     let template = '<div>'
-    //checkboxes.length === 0 && template += `<span>${x.value}</span> <br />`
     checkboxes.forEach(x => { 
-        
         if (x.checked) {  
-            holdOptions.push(x.value)
+            retainOptions.push(x)
             template += `<span>${x.value}</span> <br />`}
     })
-    if (holdOptions.length === 0) {template += `<span><b>Select an option before proceeding!</b></span> <br />`}
+    if (retainOptions.length === 0) {template += `<span><b>Select an option before proceeding!</b></span> <br />`}
     template += `
         <div style="display:inline-block; margin-top:20px;">
-            ${(holdOptions.length === 0) ? 
+            ${(retainOptions.length === 0) ? 
                 ` <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank" id="proceedFormPage" disabled>Confirm</button>`
             : ` <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank" id="proceedFormPage">Confirm</button>`
             }
@@ -163,23 +182,29 @@ const optionsHandler = () => {
         </div>
     </div>`
     body.innerHTML = template;
-    proceedToNextPage(holdOptions)
+    proceedToNextPage(retainOptions)
 } 
 
 
-export const proceedToNextPage = (holdOptions) => {
-  
+export const proceedToNextPage = (retainOptions) => {
     const a = document.getElementById('proceedFormPage');
     if (a) {
         a.addEventListener('click',  () => { 
             let checkedValue = document.getElementById('messageCheckbox').checked
-            checkedValue ? causeOfDeathPage(holdOptions) : reasonForRefusalPage(holdOptions);
+            checkedValue ? causeOfDeathPage(retainOptions) : reasonForRefusalPage(retainOptions);
         })
     }
 }
 
+const retainPreviouslySetOptions = (retainOptions) => {
+   retainOptions &&  (
+        retainOptions.forEach (x => { 
+            let checkedValue = document.getElementById(x.id);
+            checkedValue.checked = true;
+        }))
+}
 
-export const reasonForRefusalPage = (holdOptions) => {
+export const reasonForRefusalPage = (retainOptions) => {
 
     let renderContent = document.getElementById('formMainPage');
     let template = ``;
@@ -196,25 +221,29 @@ export const reasonForRefusalPage = (holdOptions) => {
             <div>
                     <span><h6>Reason for refusal/withdrawal (select all that apply):​</h6></span>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I’m no longer interested in the study​" name="options" id="defaultCheck1">
+                        <input class="form-check-input" type="checkbox" value="I’m no longer interested in the study​" name="options" 
+                        id="defaultCheck1">
                         <label class="form-check-label" for="defaultCheck1">
                             I’m no longer interested in the study​
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I’m too busy/the study takes too much time​" name="options" id="defaultCheck2">
+                        <input class="form-check-input" type="checkbox" value="I’m too busy/the study takes too much time​" name="options" 
+                        data-optionKey=${fieldMapping.tooBusy} id="defaultCheck2">
                         <label class="form-check-label" for="defaultCheck2">
                             I’m too busy/the study takes too much time​
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I’m concerned about my privacy​" name="options" id="defaultCheck3">
+                        <input class="form-check-input" type="checkbox" value="I’m concerned about my privacy​" name="options" 
+                        data-optionKey=${fieldMapping.concernedAboutPrivacy} id="defaultCheck3">
                         <label class="form-check-label" for="defaultCheck3">
                             I’m concerned about my privacy​
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I’m not able to complete the study activities online" name="options" id="defaultCheck4">
+                        <input class="form-check-input" type="checkbox" value="I’m not able to complete the study activities online" name="options" 
+                        data-optionKey=${fieldMapping.concernedAboutPrivacy} id="defaultCheck4">
                         <label class="form-check-label" for="defaultCheck4">
                             I’m not able to complete the study activities online
                         </label>
@@ -226,19 +255,22 @@ export const reasonForRefusalPage = (holdOptions) => {
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I think the incentive or benefit to participate is not great enough" name="options" id="defaultCheck6">
+                        <input class="form-check-input" type="checkbox" value="I think the incentive or benefit to participate is not great enough" name="options" 
+                        data-optionKey=${fieldMapping.participantGreedy} id="defaultCheck6">
                         <label class="form-check-label" for="defaultCheck6">
                             I think the incentive or benefit to participate is not great enough
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I’m too sick/my health is too poor to participate" name="options" id="defaultCheck7">
+                        <input class="form-check-input" type="checkbox" value="I’m too sick/my health is too poor to participate" name="options" 
+                        data-optionKey=${fieldMapping.tooSick} id="defaultCheck7">
                         <label class="form-check-label" for="defaultCheck7">
                             I’m too sick/my health is too poor to participate
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I don’t have reliable access to the internet/a device" name="options" id="defaultCheck8">
+                        <input class="form-check-input" type="checkbox" value="I don’t have reliable access to the internet/a device" name="options" 
+                        data-optionKey=${fieldMapping.noInternet} id="defaultCheck8">
                         <label class="form-check-label" for="defaultCheck8">
                             I don’t have reliable access to the internet/a device
                         </label>
@@ -251,116 +283,132 @@ export const reasonForRefusalPage = (holdOptions) => {
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I’m worried about receiving results from the study" name="options" id="defaultCheck9">
+                        <input class="form-check-input" type="checkbox" value="I’m worried about receiving results from the study" name="options" 
+                        data-optionKey=${fieldMapping.worriedAboutResults} id="defaultCheck9">
                         <label class="form-check-label" for="defaultCheck9">
                             I’m worried about receiving results from the study
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I’m worried the study might find something concerning about me" name="options" id="defaultCheck10">
+                        <input class="form-check-input" type="checkbox" value="I’m worried the study might find something concerning about me" name="options" 
+                        data-optionKey=${fieldMapping.concernedAboutResults} id="defaultCheck10">
                         <label class="form-check-label" for="defaultCheck10">
                             I’m worried the study might find something concerning about me
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I don’t trust the government" name="options" id="defaultCheck11">
+                        <input class="form-check-input" type="checkbox" value="I don’t trust the government" name="options" 
+                        data-optionKey=${fieldMapping.doesntTrustGov} id="defaultCheck11">
                         <label class="form-check-label" for="defaultCheck11">
                             I don’t trust the government
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I don’t trust research/researchers" name="options" id="defaultCheck12">
+                        <input class="form-check-input" type="checkbox" value="I don’t trust research/researchers" name="options" 
+                        data-optionKey=${fieldMapping.doesntTrustResearch} id="defaultCheck12">
                         <label class="form-check-label" for="defaultCheck12">
                             I don’t trust research/researchers
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I don’t want my information shared with other researchers" name="options" id="defaultCheck13">
+                        <input class="form-check-input" type="checkbox" value="I don’t want my information shared with other researchers" name="options" 
+                        data-optionKey=${fieldMapping.doesntWantInfoWithResearchers} id="defaultCheck13">
                         <label class="form-check-label" for="defaultCheck13">
                             I don’t want my information shared with other researchers
                         </label>
                     </div>
                     <div class="form-check">
-                            <input class="form-check-input" type="checkbox" value="I’m worried my information isn’t secure or there will be a data breach" name="options" id="defaultCheck14">
+                            <input class="form-check-input" type="checkbox" value="I’m worried my information isn’t secure or there will be a data breach" name="options" 
+                            data-optionKey=${fieldMapping.worriedAboutDataBreach} id="defaultCheck14">
                             <label class="form-check-label" for="defaultCheck14">
                                 I’m worried my information isn’t secure or there will be a data breach
                             </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I’m worried about data being given to my insurance company/effects on insurance (health, life, other)" name="options" id="defaultCheck15">
+                        <input class="form-check-input" type="checkbox" value="I’m worried about data being given to my insurance company/effects on insurance (health, life, other)" name="options" 
+                        data-optionKey=${fieldMapping.worriedAboutInsurance} id="defaultCheck15">
                         <label class="form-check-label" for="defaultCheck15">
                             I’m worried about data being given to my insurance company/effects on insurance (health, life, other)
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I’m worried about data being given to my employer/potential employer" name="options" id="defaultCheck16">
+                        <input class="form-check-input" type="checkbox" value="I’m worried about data being given to my employer/potential employer" name="options" 
+                        data-optionKey=${fieldMapping.worriedAboutEmployer} id="defaultCheck16">
                         <label class="form-check-label" for="defaultCheck16">
                             I’m worried about data being given to my employer/potential employer
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I’m worried that my information could be used to discriminate against me/my family" name="options" id="defaultCheck17">
+                        <input class="form-check-input" type="checkbox" value="I’m worried that my information could be used to discriminate against me/my family" name="options" 
+                        data-optionKey=${fieldMapping.worriedAboutDiscrimination} id="defaultCheck17">
                         <label class="form-check-label" for="defaultCheck17">
                             I’m worried that my information could be used to discriminate against me/my family
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I’m worried that my information will be used by others to make a profit" name="options" id="defaultCheck17">
-                        <label class="form-check-label" for="defaultCheck17">
+                        <input class="form-check-input" type="checkbox" value="I’m worried that my information will be used by others to make a profit" name="options" 
+                        data-optionKey=${fieldMapping.worriedAboutInformationMisue} id="defaultCheck18">
+                        <label class="form-check-label" for="defaultCheck18">
                              I’m worried that my information will be used by others to make a profit
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I have other privacy concerns" name="options" id="defaultCheck17">
-                        <label class="form-check-label" for="defaultCheck17">
+                        <input class="form-check-input" type="checkbox" value="I have other privacy concerns" name="options" 
+                        data-optionKey=${fieldMapping.worriedAboutOtherPrivacyConcerns} id="defaultCheck19">
+                        <label class="form-check-label" for="defaultCheck19">
                             I have other privacy concerns
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="I’m concerned about COVID-19" name="options" id="defaultCheck17">
-                        <label class="form-check-label" for="defaultCheck17">
+                        <input class="form-check-input" type="checkbox" value="I’m concerned about COVID-19" name="options" 
+                        data-optionKey=${fieldMapping.concernedAboutCovid} id="defaultCheck20">
+                        <label class="form-check-label" for="defaultCheck20">
                             I’m concerned about COVID-19
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="Participant is now unable to participate" name="options" id="defaultCheck17">
-                        <label class="form-check-label" for="defaultCheck17">
+                        <input class="form-check-input" type="checkbox" value="Participant is now unable to participate" name="options" 
+                        data-optionKey=${fieldMapping.participantUnableToParticipate} id="defaultCheck21">
+                        <label class="form-check-label" for="defaultCheck21">
                             Participant is now unable to participate
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="Participant is incarcerated" name="options" id="defaultCheck17">
-                        <label class="form-check-label" for="defaultCheck17">
+                        <input class="form-check-input" type="checkbox" value="Participant is incarcerated" name="options" 
+                        data-optionKey=${fieldMapping.participantIncarcerated} id="defaultCheck22">
+                        <label class="form-check-label" for="defaultCheck22">
                             Participant is incarcerated
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="Reason not given" name="options" id="defaultCheck17">
-                        <label class="form-check-label" for="defaultCheck17">
+                        <input class="form-check-input" type="checkbox" value="Reason not given" name="options" 
+                        data-optionKey=${fieldMapping.reasonNotGiven}  id="defaultCheck23">
+                        <label class="form-check-label" for="defaultCheck23">
                             Reason not given
                         </label>
                 </div>
                 </div> 
                 <div style="display:inline-block; margin-top:20px;">
                     <button type="button" id="backToPrevPage" class="btn btn-primary">Previous</button>
-                    <button type="button" data-toggle="modal" data-target="#modalShowFinalSelectedData" id="submit" class="btn btn-success">Submit</button>
+                    <button type="button" id="submit" class="btn btn-success">Submit</button>
                 </div>
             `
 
     renderContent.innerHTML =  template;
     document.getElementById('backToPrevPage').addEventListener('click', () => {
         renderContent.innerHTML = renderParticipantWithdrawalLandingPage();
+        retainPreviouslySetOptions(retainOptions);
         autoSelectOptions();
         viewOptionsSelected();
         proceedToNextPage();
     })
     document.getElementById('submit').addEventListener('click', () => {
-        collectFinalResponse(holdOptions)
+        collectFinalResponse(retainOptions)
     })
  
 }
 
-export const causeOfDeathPage = (holdOptions) => {
+export const causeOfDeathPage = (retainOptions) => {
     let renderContent = document.getElementById('formMainPage');
     let template = ``;
     template += ` <div class="modal fade" id="modalShowFinalSelectedData" data-keyboard="false" tabindex="-1" role="dialog" data-backdrop="static" aria-hidden="true">
@@ -377,31 +425,36 @@ export const causeOfDeathPage = (holdOptions) => {
                     <br />
                     <span><b> Source of Report:​ </b></span>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" name="options" value="Spouse/partne" id="defaultCheck2">
+                        <input class="form-check-input" type="checkbox" name="options" value="Spouse/partner" 
+                        data-optionKey=${fieldMapping.spouse} id="defaultCheck2">
                         <label class="form-check-label" for="defaultCheck2">
                             Spouse/partner​
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" name="options" value="Child​" id="defaultCheck3">
+                        <input class="form-check-input" type="checkbox" name="options" value="Child​" 
+                        data-optionKey=${fieldMapping.child} id="defaultCheck3">
                         <label class="form-check-label" for="defaultCheck3">
                             Child​
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" name="options" value="Other relative or proxy" id="defaultCheck4">
+                        <input class="form-check-input" type="checkbox" name="options" value="Other relative or proxy" 
+                        data-optionKey=${fieldMapping.otherRelative} id="defaultCheck4">
                         <label class="form-check-label" for="defaultCheck4">
                             Other relative or proxy​
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" name="options" value="IHCS Staff" id="defaultCheck5">
+                        <input class="form-check-input" type="checkbox" name="options" value="IHCS Staff" 
+                        data-optionKey=${fieldMapping.ihcsStaff} id="defaultCheck5">
                         <label class="form-check-label" for="defaultCheck5">
                             IHCS Staff​
                         </label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" name="options" value="Other" id="defaultCheck6">
+                        <input class="form-check-input" type="checkbox" name="options" value="Other" 
+                        data-optionKey=${fieldMapping.other} id="defaultCheck6">
                         <label class="form-check-label" for="defaultCheck6">
                             Other
                         </label>
@@ -409,55 +462,82 @@ export const causeOfDeathPage = (holdOptions) => {
              </div>
             <div style="display:inline-block; margin-top:20px;">
                 <button type="button" id="backToPrevPage" class="btn btn-primary">Previous</button>
-                <button type="button" data-toggle="modal" data-target="#modalShowFinalSelectedData" id="submit" class="btn btn-success">Submit</button>
+                <button type="button" id="submit" class="btn btn-success">Submit</button>
             </div>
             `
     renderContent.innerHTML =  template;
     document.getElementById('backToPrevPage').addEventListener('click', () => {
-        renderContent.innerHTML = renderParticipantWithdrawalLandingPage();
+        renderContent.innerHTML = renderParticipantWithdrawalLandingPage(retainOptions);
+        retainPreviouslySetOptions(retainOptions);
         autoSelectOptions();
         viewOptionsSelected();
         proceedToNextPage();
     })
     document.getElementById('submit').addEventListener('click', () => {
-        collectFinalResponse(holdOptions)
+        collectFinalResponse(retainOptions)
     })
  
 }
 
-const collectFinalResponse = (holdOptions) => {
+const collectFinalResponse = (retainOptions) => {
     let finalOptions = []
-    const header = document.getElementById('modalHeader');
-    const body = document.getElementById('modalBody');
     let checkboxes = document.getElementsByName('options');
-    header.innerHTML = `<h5>Options Selected</h5><button type="button" id="closeModal" class="modal-close-btn" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
-    
-    let template = '<div>'
-    holdOptions.forEach(x =>  template += `<span>${x}</span> <br />`)
     checkboxes.forEach(x => { if (x.checked) {  
-        holdOptions.push(x.value)
-        finalOptions.push(x.value)
-        template += `<span>${x.value}</span> <br />`}
+        finalOptions.push(x)}
     })
-    if (finalOptions.length === 0) { template += `<span><b>Select a reason/source before submitting</b></span> <br />` }
-    template += `
-        <div style="display:inline-block; margin-top:20px;">
-        ${(finalOptions.length === 0) ? 
-            ` <button type="button" class="btn btn-success" data-dismiss="modal" target="_blank" id="sendResponses" disabled>Confirm</button>`
-        : `<button type="button" class="btn btn-success" data-dismiss="modal" target="_blank" id="sendResponses">Confirm</button>`
-        }
-            <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank">Cancel</button>
-        </div>
-    </div>`
-    body.innerHTML = template;
-    sendResponses(holdOptions);
+    sendResponses(finalOptions, retainOptions);
 }
 
-const sendResponses = (holdOptions) => {
-    const a = document.getElementById('sendResponses');
-    if (a) {
-        a.addEventListener('click',  () => { 
-            console.log('response', holdOptions)
-        })
-    }
+const sendResponses = (finalOptions, retainOptions) => {
+    let sendRefusalData = {};
+    let highestStatus = [];
+    sendRefusalData[fieldMapping.refusalOptions] = {};
+    retainOptions.forEach(x => {
+        switch (parseInt(x.dataset.optionkey)) {
+            case fieldMapping.refusedSurvey:
+            case fieldMapping.refusedBlood:
+            case fieldMapping.refusedUrine:
+            case fieldMapping.refusedMouthwash:
+            case fieldMapping.refusedSpecimenSurevys:
+            case fieldMapping.refusedSpecimenSurevys:
+            case fieldMapping.refusedFutureSamples:
+                sendRefusalData[fieldMapping.refusalOptions][x.dataset.optionkey] = fieldMapping.yes
+                break;
+            default:
+                sendRefusalData[x.dataset.optionkey] = fieldMapping.yes
+            }
+    })
+    finalOptions.forEach(x => {
+        sendRefusalData[x.dataset.optionkey] = fieldMapping.yes
+    })
+    retainOptions.forEach(x => {
+        switch (x.value) {
+            case "Refusing all future activities":
+                highestStatus.push(2)
+                break;
+            case "Revoke HIPAA authorization (no medical records)*":
+                highestStatus.push(3)
+                break;
+            case "Withdraw consent*​":
+                highestStatus.push(4)
+                break;
+            case "Destroy data*​":
+                highestStatus.push(5)
+                break;
+            case "Participant Deceased":
+                highestStatus.push(6)
+                break;
+            default:
+                highestStatus.push(1)
+            }
+    })
+    console.log('response', sendRefusalData);
+    let participationStatusScore = Math.max(...highestStatus);
+    fieldMapping.participationStatus = participationStatusScore;
+    localStorage.setItem('participationStatus', fieldMapping.participationStatus = participationStatusScore)
+    
+    const loadDetailsPage = '#participantSummary'
+    location.replace(window.location.origin + window.location.pathname + loadDetailsPage); // updates url to participantDetails upon screen update
+     
+    
 }

--- a/siteManagerDashboard/participantWithdrawalForm.js
+++ b/siteManagerDashboard/participantWithdrawalForm.js
@@ -118,7 +118,7 @@ export const renderParticipantWithdrawalLandingPage = (participant) => {
                                         </span>
                                     </div>
                 </div>`
-        
+
         template += ` <div class="modal fade" id="modalShowSelectedData" data-keyboard="false" tabindex="-1" role="dialog" data-backdrop="static" aria-hidden="true">
         <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
             <div class="modal-content sub-div-shadow">

--- a/siteManagerDashboard/utils.js
+++ b/siteManagerDashboard/utils.js
@@ -91,7 +91,6 @@ import { keyToNameObj } from './siteKeysToName.js';
 
 export const siteKeyToName = (key) => {
   
-  console.log('key', key, keyToNameObj[key])
   return keyToNameObj[key];
 
 }
@@ -143,3 +142,12 @@ export const getIdToken = () => {
       });
   });
 };
+
+// shows/hides a spinner when HTTP request is made/screen is loading
+export const showAnimation = () => {
+  if(document.getElementById('loadingAnimation')) document.getElementById('loadingAnimation').style.display = '';
+}
+
+export const hideAnimation = () => {
+  if(document.getElementById('loadingAnimation')) document.getElementById('loadingAnimation').style.display = 'none';
+}


### PR DESCRIPTION
This PR addresses the following features & issues (#58 #66):
-> Participant Withdrawal, api call integrated & concept ids added to options
-> Added necessary participant summary variables
-> Participant Withdrawal only available to parent site keys

Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [x] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added
- [ ] Attach PoC
- [x] Notes added

Notes: 
Pending: Add date fields, update participant status variable, fix All option on Filter by Site option

Test case 1:
**Check for updated Participant Status on Participant Header after api call**
<img width="1755" alt="Screen Shot 2021-05-04 at 4 50 41 PM" src="https://user-images.githubusercontent.com/30497847/117373327-06aa8580-ae99-11eb-8ed8-2f8d2f9e30c5.png">
Test case 2:
**Participant withdrawal only available for participant parent site key**
<img width="1749" alt="Screen Shot 2021-05-06 at 6 32 01 PM" src="https://user-images.githubusercontent.com/30497847/117373527-63a63b80-ae99-11eb-975a-1aec1d11d6bb.png">

