### PR TITLE
[Site Manager Dashboard] Added inactivity check

### DIFF
--- a/siteManagerDashboard/index.js
+++ b/siteManagerDashboard/index.js
@@ -919,7 +919,7 @@ const activityCheckController = () => {
                     resetTimer;
                 })
             });
-        }, 30000);
+        }, 300000);
     }
     window.onload = resetTimer;
     document.onmousemove = resetTimer;

--- a/siteManagerDashboard/index.js
+++ b/siteManagerDashboard/index.js
@@ -919,7 +919,7 @@ const activityCheckController = () => {
                     resetTimer;
                 })
             });
-        }, 300000);
+        }, 1200000);
     }
     window.onload = resetTimer;
     document.onmousemove = resetTimer;


### PR DESCRIPTION
This PR addressed following feature:
Upon 20 minutes of inactivity, the application throws an alert asking the user if they would like to extend the 
<img width="1713" alt="Screen Shot 2021-06-24 at 11 26 11 AM" src="https://user-images.githubusercontent.com/30497847/123297150-4f6bdb80-d4e5-11eb-90e7-1450ad652354.png">
session or logout. If no response, then user is logged out of the session.

Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [x] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added [PDF-lib.js & download.js]
- [x] Attach PoC
- [ ] Notes added


Test Cases:
-> Test Case 1: An alert should show up when the user is inactive for more than 20 minutes
-> Test Case 2: Should extend the session upon clicking on stay
-> Test Case 3: Should logout the user upon clicking on logged out. And should automatically log out of session when no response is selected on the inactivity alert modal after 5 minutes

PoC: 
<img width="1713" alt="Screen Shot 2021-06-24 at 11 26 11 AM" src="https://user-images.githubusercontent.com/30497847/123297407-8b9f3c00-d4e5-11eb-867f-6f4d363cf87c.png">


