### PR TITLE
[Site Manager Dashboard] Add date requested Participant Withdrawal

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -337,6 +337,10 @@ export default
     "destroyDataStatus": 241236037,
     "deceased": 987563196,
 
+    'dateWithdrewConsentRequested': 659990606,
+    'dateDataDestroyRequested': 269050420,
+    'dateHipaaRevokeRequested': 664453818,
+
 
     'sourceOfDeath': 764403541,
     'dateOfDeath': 123868967,

--- a/siteManagerDashboard/participantWithdrawalForm.js
+++ b/siteManagerDashboard/participantWithdrawalForm.js
@@ -440,7 +440,13 @@ const sendResponses = async (finalOptions, retainOptions, requestedHolder, sourc
         :
             ( sendRefusalData[x.dataset.optionkey] = fieldMapping.yes )
         }))
-    if (retainOptions.length !== 0) sendRefusalData[fieldMapping.participationStatus] = computeScore(retainOptions, highestStatus);
+    const computeScore = getComputeScore(retainOptions, highestStatus);
+    if (retainOptions.length !== 0) sendRefusalData[fieldMapping.participationStatus] = computeScore
+    
+    if (computeScore === fieldMapping.withdrewConsent) { sendRefusalData[fieldMapping.dateWithdrewConsentRequested] = new Date().toISOString(); }
+    if (computeScore === fieldMapping.destroyDataStatus) { sendRefusalData[fieldMapping.dateDataDestroyRequested] = new Date().toISOString(); }
+    if (computeScore === fieldMapping.revokeHIPAAOnly) { sendRefusalData[fieldMapping.dateHipaaRevokeRequested] = new Date().toISOString(); }
+    
     let refusalObj = sendRefusalData[fieldMapping.refusalOptions]
     if (JSON.stringify(refusalObj) === '{}') delete sendRefusalData[fieldMapping.refusalOptions]
     const token = localStorage.getItem("token");
@@ -449,7 +455,7 @@ const sendResponses = async (finalOptions, retainOptions, requestedHolder, sourc
     clickHandler(sendRefusalData, siteKey, token);
 }
 
-const computeScore = (retainOptions, highestStatus) => {
+const getComputeScore = (retainOptions, highestStatus) => {
     retainOptions.forEach(x => {
         switch (x.value) {
             case "Refusing all future activities":


### PR DESCRIPTION
 Added following concept ids; date requested in withdrawal status:
 
    https://episphere.github.io/conceptGithubActions/web/#659990606

    https://episphere.github.io/conceptGithubActions/web/#269050420

    https://episphere.github.io/conceptGithubActions/web/#664453818
    
    PoC:
    
<img width="1195" alt="Screen Shot 2021-08-11 at 5 26 41 PM" src="https://user-images.githubusercontent.com/30497847/129106005-9a5ce8a8-2728-4c13-a5c9-096baeec6090.png">

