### PR TITLE
[HotFix] Fixed Suspend Contact 

### DIFF
--- a/siteManagerDashboard/participantWithdrawalForm.js
+++ b/siteManagerDashboard/participantWithdrawalForm.js
@@ -289,7 +289,7 @@ const optionsHandler = (suspendDate) => {
     if (suspendDate !== '//') template += `<span>Suspend all contact on case until ${suspendDate}</span> <br />`
     template += `
         <div style="display:inline-block; margin-top:20px;">
-            ${ ( skipRequestedBy === true &&  requestedHolder.length >= 0) ?  
+            ${ ( suspendDate !== '//' || (skipRequestedBy === true && requestedHolder.length >= 0)) ?  
                 ` <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank" id="proceedFormPage">Confirm</button>`
             :  ( retainOptions.length === 0 || requestedHolder.length === 0 ) ? 
             `<span><b>Select an option & requested by before proceeding!</b></span> <br />


### PR DESCRIPTION
This PR addresses following issue:
-> _In scenario 5, when trying to suspend the case until December 1st.   We enter in the date,  and also selected a value for “who requested”, but after hitting next the pop up says: Select an option & requested by before proceeding.  It seems to want us to pick something on the left hand side of the screen, but I thought that was supposed to be blank for suspended cases._