### PR TITLE
[HotFix] Participant Withdrawal Feature Request

### DIFF
--- a/siteManagerDashboard/participantHeader.js
+++ b/siteManagerDashboard/participantHeader.js
@@ -112,7 +112,7 @@ const renderSiteLocation = (participant) => {
     return keyToNameObj[siteHealthcareProvider];
 }
 
-const getParticipationStatus = (participant) => {
+export const getParticipationStatus = (participant) => {
    if (typeof participant !== "string") {
         const statusValue = participant[fieldMapping.participationStatus];
         if (statusValue !== undefined)  return fieldMapping[statusValue];

--- a/siteManagerDashboard/participantHeader.js
+++ b/siteManagerDashboard/participantHeader.js
@@ -28,11 +28,11 @@ export const renderParticipantHeader = (participant) => {
         :
 
         (headerImportantColumns[x].field === 'Participation Status' ) ?
-            template += `<span><b>Participation Status </b></span> : ${getParticipationStatus(participant)}  &nbsp;`
+            template += `<span><b>Participation Status </b></span> : ${getParticipantStatus(participant)}  &nbsp;`
         :
 
         (headerImportantColumns[x].field === 'Suspended Contact'  ) ?
-            template += getParticipationSuspendedDate(participant)
+            template += getParticipantSuspendedDate(participant)
         :
 
         (headerImportantColumns[x].field === 'Year(s) in Connect' ) ?
@@ -112,15 +112,15 @@ const renderSiteLocation = (participant) => {
     return keyToNameObj[siteHealthcareProvider];
 }
 
-export const getParticipationStatus = (participant) => {
+export const getParticipantStatus = (participant) => {
    if (typeof participant !== "string") {
         const statusValue = participant[fieldMapping.participationStatus];
-        if (statusValue !== undefined)  return fieldMapping[statusValue];
+        if (statusValue !== undefined && statusValue !== ``)  return fieldMapping[statusValue];
         else return `No Refusal`;
     }
 }
 
-const getParticipationSuspendedDate = (participant) => {
+export const getParticipantSuspendedDate = (participant) => {
     if (participant[fieldMapping.suspendContact] !== "" && participant[fieldMapping.suspendContact] !== undefined ) {
         let currentTimeStamp = humanReadableMDY(new Date().toISOString());
         let suspendedDate = participant[fieldMapping.suspendContact]

--- a/siteManagerDashboard/participantWithdrawal.js
+++ b/siteManagerDashboard/participantWithdrawal.js
@@ -1,6 +1,6 @@
 import {renderNavBarLinks, dashboardNavBarLinks, removeActiveClass} from './navigationBar.js';
 import fieldMapping from './fieldToConceptIdMapping.js';
-import { renderParticipantHeader, getParticipationStatus } from './participantHeader.js';
+import { renderParticipantHeader, getParticipantStatus, getParticipantSuspendedDate } from './participantHeader.js';
 import { renderParticipantWithdrawalLandingPage, viewOptionsSelected, proceedToNextPage, autoSelectOptions, addEventMonthSelection } from './participantWithdrawalForm.js'
 
 
@@ -36,20 +36,29 @@ export const render = (participant) => {
         template += `<div id="formMainPage">
                     ${renderParticipantWithdrawalLandingPage()}
                     </div></div>`
-}
-return template;
     }
+    return template;
+}
 
 const checkPreviousWithdrawalStatus = (participant) => {
     let template = ``;
     let alertList = document.getElementById('alert_placeholder');
-    if (participant[fieldMapping.participationStatus] !== fieldMapping.noRefusal) {
+    if (participant[fieldMapping.participationStatus] !== fieldMapping.noRefusal && participant[fieldMapping.participationStatus] !== ``) {
+        localStorage.setItem('participationStatus', true)
         template += `<div class="alert alert-warning alert-dismissible fade show" role="alert">
-                        Previously Selected Refusal Option: <b> ${getParticipationStatus(participant)} </b>
+                        Previously Selected Refusal Option: <b> ${getParticipantStatus(participant)} </b>
                         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                         </button>
                     </div>`
-    } 
+    } else if (participant[fieldMapping.suspendContact] !== "" && participant[fieldMapping.suspendContact] !== ``) {
+        localStorage.setItem('suspendContact', true)
+        template += `<div class="alert alert-warning alert-dismissible fade show" role="alert">
+                        <b> ${getParticipantSuspendedDate(participant)} </b>
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>`
+    }
     alertList.innerHTML = template;
 }

--- a/siteManagerDashboard/participantWithdrawal.js
+++ b/siteManagerDashboard/participantWithdrawal.js
@@ -1,5 +1,6 @@
 import {renderNavBarLinks, dashboardNavBarLinks, removeActiveClass} from './navigationBar.js';
-import { renderParticipantHeader } from './participantHeader.js';
+import fieldMapping from './fieldToConceptIdMapping.js';
+import { renderParticipantHeader, getParticipationStatus } from './participantHeader.js';
 import { renderParticipantWithdrawalLandingPage, viewOptionsSelected, proceedToNextPage, autoSelectOptions, addEventMonthSelection } from './participantWithdrawalForm.js'
 
 
@@ -13,6 +14,7 @@ export const renderParticipantWithdrawal = (participant) => {
     viewOptionsSelected();
     proceedToNextPage();
     addEventMonthSelection('UPMonth', 'UPDay');
+    checkPreviousWithdrawalStatus(participant);
 }
 
 
@@ -30,14 +32,24 @@ export const render = (participant) => {
         template += `
                 <div id="root root-margin"> `
         template += renderParticipantHeader(participant);
+        template += `<div id="alert_placeholder"></div>`
         template += `<div id="formMainPage">
-                    ${renderParticipantWithdrawalLandingPage(participant)}
+                    ${renderParticipantWithdrawalLandingPage()}
                     </div></div>`
 }
 return template;
     }
 
-
-
-
-
+const checkPreviousWithdrawalStatus = (participant) => {
+    let template = ``;
+    let alertList = document.getElementById('alert_placeholder');
+    if (participant[fieldMapping.participationStatus] !== fieldMapping.noRefusal) {
+        template += `<div class="alert alert-warning alert-dismissible fade show" role="alert">
+                        Previously Selected Refusal Option: <b> ${getParticipationStatus(participant)} </b>
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>`
+    } 
+    alertList.innerHTML = template;
+}

--- a/siteManagerDashboard/participantWithdrawalForm.js
+++ b/siteManagerDashboard/participantWithdrawalForm.js
@@ -100,7 +100,7 @@ export const renderParticipantWithdrawalLandingPage = () => {
                                     </label>
                                 </div>
                                 &nbsp;
-                                ${  (participant[fieldMapping.participationStatus] === fieldMapping.noRefusal) && (participant[fieldMapping.suspendContact] === "") ?
+                                ${  (participant[fieldMapping.suspendContact] === "") ?
                                         (`<button type="button" data-toggle="modal" data-target="#modalShowSelectedData"
                                         class="btn btn-primary next-btn" id="nextFormPage" style="margin-top:40px;">Next</button>`)
                                   :

--- a/siteManagerDashboard/participantWithdrawalForm.js
+++ b/siteManagerDashboard/participantWithdrawalForm.js
@@ -3,7 +3,6 @@ import { showAnimation, hideAnimation, baseAPI, getAccessToken } from './utils.j
 import { renderRefusalOptions, renderCauseOptions } from './participantWithdrawalRender.js';
 
 export const renderParticipantWithdrawalLandingPage = () => {
-    let participant = JSON.parse(localStorage.getItem("participant"))
     let template = ``;
     template = `        
                 <div class="row">
@@ -100,12 +99,8 @@ export const renderParticipantWithdrawalLandingPage = () => {
                                     </label>
                                 </div>
                                 &nbsp;
-                                ${  (participant[fieldMapping.suspendContact] === "") ?
-                                        (`<button type="button" data-toggle="modal" data-target="#modalShowSelectedData"
-                                        class="btn btn-primary next-btn" id="nextFormPage" style="margin-top:40px;">Next</button>`)
-                                  :
-                                        (`<button type="button" class="btn btn-secondary" disabled>Next</button>`)
-                                  }  
+                                <button type="button" data-toggle="modal" data-target="#modalShowSelectedData"
+                                    class="btn btn-primary next-btn" id="nextFormPage" style="margin-top:40px;">Next</button>
                                 </div>
                         </div>
                     </div>
@@ -431,6 +426,13 @@ const sendResponses = async (finalOptions, retainOptions, requestedHolder, sourc
         })
     }
     if (suspendDate !== '//' && source !== 'page2') sendRefusalData[fieldMapping.suspendContact] = suspendDate
+
+    const previousSuspendedStatus = localStorage.getItem('suspendContact');
+    if (previousSuspendedStatus === 'true' && suspendDate === '//') sendRefusalData[fieldMapping.suspendContact] = ``
+
+    const previousRefusalStatus = localStorage.getItem('participationStatus');
+    if (previousRefusalStatus === 'true' && suspendDate !== '//') sendRefusalData[fieldMapping.participationStatus] = ``
+    
     source === 'page2' ? (
         combineResponses(finalOptions, sendRefusalData, suspendDate)
     ) : (


### PR DESCRIPTION
**This PR addresses following issue:**

_In scenario 8, we had the participant refuse to do future samples one day, and then want to withdraw the next.     When we went in to do the withdrawal,  it won’t let us enter it.   We check withdrawal, requested by participant, but the “next” button is never activated._

**Checklist:**
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [x] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added 
- [x] Attach PoC
- [ ] Notes added


**PoC:**

<img width="893" alt="Screen Shot 2021-08-19 at 3 17 24 PM" src="https://user-images.githubusercontent.com/30497847/130146870-9840f2c7-f21d-4ada-8488-9b435db15741.png">
<img width="900" alt="Screen Shot 2021-08-19 at 3 17 47 PM" src="https://user-images.githubusercontent.com/30497847/130146877-eee28a94-330f-4a3e-bf53-c7802ddf21ec.png">

**Test Case 1:** User can change Participant with suspended contact to refusal 
<img width="901" alt="Screen Shot 2021-08-19 at 5 33 02 PM" src="https://user-images.githubusercontent.com/30497847/130147244-528a4e63-5c7b-46e8-870a-86ba48ff0893.png">
<img width="1789" alt="Screen Shot 2021-08-19 at 5 33 23 PM" src="https://user-images.githubusercontent.com/30497847/130147274-72433e08-5e61-4a9a-a8f8-0f76f93a13d1.png">

**Test Case 2:** User with suspended contact can change Participant to refusal activity
<img width="902" alt="Screen Shot 2021-08-19 at 5 34 56 PM" src="https://user-images.githubusercontent.com/30497847/130147429-90e31c46-b930-4f2d-924d-112d8133eedd.png">
<img width="1785" alt="Screen Shot 2021-08-19 at 5 35 19 PM" src="https://user-images.githubusercontent.com/30497847/130147464-5807bf9c-93f4-43e7-ab31-861b031f6fb8.png">

