### PR TITLE
SiteManager Dashboard: Moved local storage from reRenderTableParticipantsAllTable to render Pts table

### DIFF
--- a/siteManagerDashboard/index.js
+++ b/siteManagerDashboard/index.js
@@ -1029,6 +1029,7 @@ const renderParticipantsAll = async () => {
         document.getElementById('participants').classList.add('active');
         mainContent.innerHTML = renderTable(filterdata(response.data), 'participantAll');
         addEventFilterData(filterdata(response.data));
+        localStorage.setItem('filterRawData', JSON.stringify(filterRawData))
         renderData(filterdata(response.data));
         activeColumns(filterdata(response.data));
         renderLookupSiteDropdown();

--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -658,7 +658,6 @@ const reRenderTableParticipantsAllTable = async (query, sitePref, currentSiteSel
         const mainContent = document.getElementById('mainContent')
         let filterRawData = filterdata(response.data);
         if (filterRawData.length === 0)  return alertTrigger();
-        localStorage.setItem('filterRawData', JSON.stringify(filterRawData))
         mainContent.innerHTML = renderTable(filterRawData, 'participantAll');
         addEventFilterData(filterRawData);
         renderData(filterRawData);


### PR DESCRIPTION
Moved local storage from reRenderTableParticipantsAllTable to renderParticipants table function to prevent overload of local storage

Related Issue:https://github.com/episphere/dashboard/issues/414