### PR TITLE
SiteManager Dashboard: Moved local storage from reRenderTableParticipantsAllTable to render Pts table

### DIFF
--- a/siteManagerDashboard/index.js
+++ b/siteManagerDashboard/index.js
@@ -1027,11 +1027,12 @@ const renderParticipantsAll = async () => {
         document.getElementById('allBtn').classList.add('dd-item-active');
         removeActiveClass('nav-link', 'active');
         document.getElementById('participants').classList.add('active');
-        mainContent.innerHTML = renderTable(filterdata(response.data), 'participantAll');
-        addEventFilterData(filterdata(response.data));
+        const filterRawData = filterdata(response.data)
+        mainContent.innerHTML = renderTable(filterRawData, 'participantAll');
+        addEventFilterData(filterRawData);
         localStorage.setItem('filterRawData', JSON.stringify(filterRawData))
-        renderData(filterdata(response.data));
-        activeColumns(filterdata(response.data));
+        renderData(filterRawData);
+        activeColumns(filterRawData);
         renderLookupSiteDropdown();
         dropdownTriggerAllParticipants('Filter by Site');
         animation(false);


### PR DESCRIPTION
Moved local storage from reRenderTableParticipantsAllTable to renderParticipants table function to prevent overload of local storage

PR addresses following Issue: https://github.com/episphere/dashboard/issues/414
Related PR: https://github.com/episphere/dashboard/pull/415