### PR TITLE
SiteManager Dashboard: Updated Back to Search functionality

### DIFF
--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -2,7 +2,7 @@ import { renderParticipantDetails } from './participantDetails.js';
 import { animation } from './index.js'
 import fieldMapping from './fieldToConceptIdMapping.js'; 
 export const importantColumns = [fieldMapping.fName, fieldMapping.mName, fieldMapping.lName, fieldMapping.birthMonth, fieldMapping.birthDay, fieldMapping.birthYear, fieldMapping.email, 'Connect_ID', fieldMapping.healthcareProvider];
-import { getAccessToken, getDataAttributes, showAnimation, hideAnimation, baseAPI, urls, filterState, getState  } from './utils.js';
+import { getAccessToken, getDataAttributes, showAnimation, hideAnimation, baseAPI, urls, createStore  } from './utils.js';
 import { findParticipant } from './participantLookup.js';
 import { nameToKeyObj, keyToNameObj, keyToShortNameObj } from './siteKeysToName.js';
 
@@ -116,16 +116,16 @@ export const renderTable = (data, source) => {
     return template;
 }
 
-export  const renderData = (data, showButtons, flag) => {
+const appState = createStore();
+
+export  const renderData = (data, showButtons) => {
     if(data.length === 0) {
         const mainContent = document.getElementById('mainContent');
         mainContent.innerHTML = renderTable(data);
         animation(false); 
         return;
     }
-    const returnedFilters = getState()
-    if (Object.keys(returnedFilters.results).length !== 0) {reMapFilters(returnedFilters.results)}
-   
+    if (Object.keys(appState.getState()).length !== 0) { reMapFilters(appState.getState()) }
     const pageSize = 50;
     const dataLength = data.length;
     data.splice(pageSize, dataLength);
@@ -175,7 +175,7 @@ const reMapFilters = async (filters) =>  {
     const response = await getCurrentSelectedParticipants(query)
     reRenderMainTable(response, type, selectedSite, startDate, endDate)
     filterHolder = filters
-    filterState.setState({})
+    appState.setState({})
 }
 
 const renderDataTable = (data, showButtons) => {
@@ -792,7 +792,7 @@ const tableTemplate = (data, showButtons) => {
     return template;
 }
 
-const addEventShowMoreInfo = data => {
+const addEventShowMoreInfo = (data) => {
     const elements = document.getElementsByClassName('showMoreInfo');
     Array.from(elements).forEach(element => {
         element.addEventListener('click', () => {
@@ -821,7 +821,7 @@ const addEventShowMoreInfo = data => {
     const selectElements = document.getElementsByClassName('select-participant');
     Array.from(selectElements).forEach(element => {
         element.addEventListener('click', async () => {
-            filterState.setState(filterHolder)
+            appState.setState(filterHolder)
             const filteredData = data.filter(dt => dt.token === element.dataset.token);
             let adminSubjectAudit = [];
             let changedOption = {};

--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -959,8 +959,7 @@ const reRenderTableParticipantsAllTable = async (query, sitePref, currentSiteSel
     showAnimation();
     const sitePrefId = nameToKeyObj[sitePref];
     let prevState = appState.getState().filterHolder
-    appState.setState({filterHolder:{...prevState, 'siteCode': sitePrefId}})
-    appState.setState({filterHolder:{...prevState, 'siteName': sitePref}})
+    appState.setState({filterHolder:{...prevState, 'siteCode': sitePrefId, 'siteName': sitePref}})
     const response = await getParticipantFromSites(sitePrefId);
     hideAnimation();
     if(response.code === 200 && response.data.length > 0) {

--- a/siteManagerDashboard/stateManager.js
+++ b/siteManagerDashboard/stateManager.js
@@ -1,0 +1,41 @@
+
+// // State Management
+const createStore = (startState = {}) => {
+    let state = startState;
+    const setState = (newState) => { 
+      state = {...state, ...newState}
+    }
+    const getState = () => { return state }
+    return {
+      setState,
+      getState,
+    };
+  }
+  
+
+
+export const appState = createStore();
+  
+  
+  
+//   let filters={name: 'John', age: 30};
+  
+  
+  
+//   appState.setState({filters, name: 'John', age: 30});
+  
+//   console.log(appState.getState());
+  
+  
+  
+//   filters={name: 'mike', age: 60};
+  
+//   appState.setState({filters, users:{name: 'mike', age: 60}});
+  
+//   console.log(appState.getState());
+  
+  
+  
+//   appState.setState({filters:{}});
+  
+//   console.log(appState.getState());

--- a/siteManagerDashboard/stateManager.js
+++ b/siteManagerDashboard/stateManager.js
@@ -1,7 +1,7 @@
 
 // // State Management
 const createStore = (startState = {}) => {
-    let state = startState;
+    let state = JSON.parse(JSON.stringify(startState));
     const setState = (newState) => { 
       state = {...state, ...newState}
     }

--- a/siteManagerDashboard/stateManager.js
+++ b/siteManagerDashboard/stateManager.js
@@ -15,27 +15,3 @@ const createStore = (startState = {}) => {
 
 
 export const appState = createStore();
-  
-  
-  
-//   let filters={name: 'John', age: 30};
-  
-  
-  
-//   appState.setState({filters, name: 'John', age: 30});
-  
-//   console.log(appState.getState());
-  
-  
-  
-//   filters={name: 'mike', age: 60};
-  
-//   appState.setState({filters, users:{name: 'mike', age: 60}});
-  
-//   console.log(appState.getState());
-  
-  
-  
-//   appState.setState({filters:{}});
-  
-//   console.log(appState.getState());

--- a/siteManagerDashboard/utils.js
+++ b/siteManagerDashboard/utils.js
@@ -136,3 +136,18 @@ export const getAccessToken = async () => {
   const siteKey = access_token !== null ? access_token : localStr.siteKey
   return siteKey;
 }
+
+export const filterState =  {
+  results: {},
+  setState: (filters) => {
+    storeFilters(() => filterState.results = filters);
+  }
+}
+
+const storeFilters = (callback) => {
+  callback();
+}
+
+export const getState = () => {
+  return filterState
+};

--- a/siteManagerDashboard/utils.js
+++ b/siteManagerDashboard/utils.js
@@ -137,17 +137,3 @@ export const getAccessToken = async () => {
   return siteKey;
 }
 
-
-// // State Management
-export const createStore = () => {
-  let state = {}
-  const setState = (newState) => { 
-    state = newState 
-  }
-  const getState = () => { return state }
-  const store = {
-    setState,
-    getState,
-  };
-  return store;
-}

--- a/siteManagerDashboard/utils.js
+++ b/siteManagerDashboard/utils.js
@@ -138,18 +138,16 @@ export const getAccessToken = async () => {
 }
 
 
-// State Management
-export const filterState =  {
-  results: {},
-  setState: (filters) => {
-    storeFilters(() => filterState.results = filters);
+// // State Management
+export const createStore = () => {
+  let state = {}
+  const setState = (newState) => { 
+    state = newState 
   }
+  const getState = () => { return state }
+  const store = {
+    setState,
+    getState,
+  };
+  return store;
 }
-
-const storeFilters = (callback) => {
-  callback();
-}
-
-export const getState = () => {
-  return filterState
-};

--- a/siteManagerDashboard/utils.js
+++ b/siteManagerDashboard/utils.js
@@ -137,6 +137,8 @@ export const getAccessToken = async () => {
   return siteKey;
 }
 
+
+// State Management
 export const filterState =  {
   results: {},
   setState: (filters) => {


### PR DESCRIPTION
This PR addresses following issue:
https://github.com/episphere/dashboard/issues/290
-> Selected filters pertain after clicking on Back to Search button on Participants Details
-> Utilized State Management to track filters

Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [x] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added
- [ ] Attach PoC
- [x] Notes added

Notes: 
-> Reduced API call for better performance. Remap of filter from back to search triggered from index.js instead of participantsCommons.js
<img width="1745" alt="Screen Shot 2022-10-05 at 5 46 00 PM" src="https://user-images.githubusercontent.com/30497847/195162190-37021f21-5184-4881-98a7-93056d8b34a0.png">

-> Refresh the page to select new filter(s) for better results accuracy

Test case 1:
**Selected Filters should pertain after clicking back to search**
<img width="1788" alt="Screen Shot 2022-10-05 at 3 46 08 PM" src="https://user-images.githubusercontent.com/30497847/194149111-b148d5e0-4311-4639-8df3-49d7ccfdbf74.png">
<img width="1781" alt="Screen Shot 2022-10-05 at 3 50 12 PM" src="https://user-images.githubusercontent.com/30497847/194149806-180a0a93-4b30-46b8-a104-0a54e915f306.png">
<img width="1792" alt="Screen Shot 2022-10-05 at 3 50 28 PM" src="https://user-images.githubusercontent.com/30497847/194149869-c2bebc19-c4d3-470f-9211-f560ae66af51.png">

Test case 2:
**After returning from back to search, upon clicking next should still pertain filters selected**
<img width="1792" alt="Screen Shot 2022-10-05 at 3 51 44 PM" src="https://user-images.githubusercontent.com/30497847/194150124-51942ec4-556a-4399-92be-cd215e26236c.png">


