### PR TITLE
SiteManager Dashboard: DOB CID update

### DIFF
--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -302,11 +302,11 @@ const saveResponses = (participant, adminSubjectAudit, changedOption, editedElem
         let newUpdatedValue = document.getElementById('newValue').value;
         changedOption[conceptId[conceptId.length - 1]] = newUpdatedValue;
 
-        // if field is a date of birth field then need to update full date of birth  
-        if (fieldModifiedData.fieldconceptid === "564964481" || fieldModifiedData.fieldconceptid === "795827569" || conceptId === "544150384") {
-            let day = fieldModifiedData.fieldconceptid === "795827569" ? newUpdatedValue : getDataAttributes(document.getElementById('795827569')).participantvalue;
-            let month = fieldModifiedData.fieldconceptid === "564964481" ? newUpdatedValue : getDataAttributes(document.getElementById('564964481')).participantvalue;
-            let year = fieldModifiedData.fieldconceptid === "544150384" ? newUpdatedValue : getDataAttributes(document.getElementById('544150384')).participantvalue;
+        // if a changed field is a date of birth field then we need to update full date of birth  
+        if ("795827569" in changedOption || "564964481" in changedOption || "544150384" in changedOption) {
+            let day = "795827569" in changedOption ?  changedOption["795827569"] : getDataAttributes(document.getElementById('795827569')).participantvalue;
+            let month = "564964481" in changedOption ? changedOption["564964481"] : getDataAttributes(document.getElementById('564964481')).participantvalue;
+            let year = "544150384" in changedOption ? changedOption["544150384"] : getDataAttributes(document.getElementById('544150384')).participantvalue;
             conceptId.push("371067537");
             changedOption[conceptId[conceptId.length - 1]] =  year.toString() + month.padStart(2, '0')+ day.padStart(2, '0') ;
         }

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -184,7 +184,8 @@ export const render = (participant) => {
                                             : ""}</td> 
             <td style="text-align: left;"> <a class="showMore" data-toggle="modal" data-target="#modalShowMoreData" 
                 data-participantkey=${conceptIdMapping[x.field] && (conceptIdMapping[x.field] && conceptIdMapping[x.field]['Variable Label'] !== undefined) ? conceptIdMapping[x.field]['Variable Label'].replace(/\s/g, "") || conceptIdMapping[x.field]['Variable Name'].replace(/\s/g, "") : ""}
-                data-participantconceptid=${x.field} data-participantValue=${formatInputResponse(participant[x.field])} name="modalParticipantData" >
+                data-participantconceptid=${x.field} data-participantValue=${formatInputResponse(participant[x.field])} name="modalParticipantData" 
+                id=${x.field}>
                 ${(x.editable && (participant[fieldMapping.verifiedFlag] !== (fieldMapping.verified || fieldMapping.cannotBeVerified || fieldMapping.duplicate))  )? 
                     `<button type="button" class="btn btn-primary">Edit</button>`
                  : `<button type="button" class="btn btn-secondary" disabled>Edit</button>`
@@ -300,6 +301,16 @@ const saveResponses = (participant, adminSubjectAudit, changedOption, editedElem
         // new value
         let newUpdatedValue = document.getElementById('newValue').value;
         changedOption[conceptId[conceptId.length - 1]] = newUpdatedValue;
+
+        // if field is a date of birth field then need to update full date of birth  
+        if (fieldModifiedData.fieldconceptid === "564964481" || fieldModifiedData.fieldconceptid === "795827569" || conceptId === "544150384") {
+            let day = fieldModifiedData.fieldconceptid === "795827569" ? newUpdatedValue : getDataAttributes(document.getElementById('795827569')).participantvalue;
+            let month = fieldModifiedData.fieldconceptid === "564964481" ? newUpdatedValue : getDataAttributes(document.getElementById('564964481')).participantvalue;
+            let year = fieldModifiedData.fieldconceptid === "544150384" ? newUpdatedValue : getDataAttributes(document.getElementById('544150384')).participantvalue;
+            conceptId.push("371067537");
+            changedOption[conceptId[conceptId.length - 1]] =  year.toString() + month.padStart(2, '0')+ day.padStart(2, '0') ;
+        }
+        
         // update changed field on UI
         let updatedEditedValue = editedElement.querySelectorAll("td")[0];
         updatedEditedValue.innerHTML = newUpdatedValue;


### PR DESCRIPTION
Added in lines 306 - 312:
If the birth month, birth day, or birth year are updated then we need to update the full date of birth field.
Used the changedOption to get the day/month/year value when in the changedOption array so if a user updates day and month before saving then the full date of birth will have the new day/month combo.

Added in an id field equal to the conceptId on line 188
this was to make it easier to find the birth day fields to concatenate 
