### PR TITLE
Update User Edit Functionality & Profile Archiving - SMDB

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -7,6 +7,7 @@ export default
     "birthMonth":564964481,
     "birthDay":795827569,
     "birthYear":544150384,
+    "dateOfBirthComplete": 371067537,
 
     // consent
     "consentDate":454445267,
@@ -56,6 +57,9 @@ export default
     "ssnOnFile": 454067894,
     "timeProfileSubmitted": 430551721,
     'timeStudyIdSubmitted': 521025370,
+    "userProfileHistory": 569151507,
+    "profileChangeRequestedBy": 611005658,
+    "userProfileUpdateTimestamp": 371303487,
 
     'jr': 612166858,
     'sr': 255907182,

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -21,7 +21,6 @@ window.addEventListener('onload', (e) => {
     }, 15);
 })
 
-//TODO integrate Warren's code (fixing for Abhinav)
 const checkForLoginMechanism = (participant) => {
     const isPhoneLogin = participant?.[fieldMapping.signInMechansim] === `phone`;
     if (isPhoneLogin) {
@@ -231,8 +230,6 @@ const saveAltResponse = (adminSubjectAudit, participant) => {
         changedModuleOption['Last Name'] = altNewLName;
 
         let newRelationship = document.getElementById('newRelationship').value;
-        // let altFieldRelationship = getDataAttributes(document.getElementById('fieldRelationship'))
-        // let altCurrentRelationship = getDataAttributes(document.getElementById('currentRelationship'))
         changedModuleOption['Relationship'] = newRelationship;
 
 
@@ -374,7 +371,8 @@ const updateUserSigninMechanism = (participant, siteKey) => {
             processSwitchSigninMechanism(participant, siteKey, 'replaceSignin');
         })
     }
-   }
+}
+
 // updates existing email or phone
 const updateUserLogin = (participant, siteKey) => {
     const switchSiginButton = document.getElementById('updateUserLogin');

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -1,5 +1,5 @@
 import { dashboardNavBarLinks, removeActiveClass } from './navigationBar.js';
-import { allStates, closeModal, formatInputResponse, formatPhoneNumber, getFieldValues, getImportantRows, getModalLabel, hideUneditableButtons, reloadParticipantData, renderReturnSearchResults, resetChanges, saveResponses, showSaveNoteInModal, submitClickHandler, suffixList, suffixToTextMap, viewParticipantSummary, } from './participantDetailsHelpers.js';
+import { allStates, closeModal, formatInputResponse, getFieldValues, getImportantRows, getModalLabel, hideUneditableButtons, reloadParticipantData, renderReturnSearchResults, resetChanges, saveResponses, showSaveNoteInModal, submitClickHandler, suffixList, viewParticipantSummary, } from './participantDetailsHelpers.js';
 import fieldMapping from './fieldToConceptIdMapping.js'; 
 import { renderParticipantHeader } from './participantHeader.js';
 import { getDataAttributes, showAnimation, hideAnimation, baseAPI } from './utils.js';

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -35,7 +35,7 @@ const checkForLoginMechanism = (participant) => {
     }
 }
 
-export const renderParticipantDetails = async (participant, adminSubjectAudit, changedOption, siteKey) => {
+export const renderParticipantDetails = (participant, adminSubjectAudit, changedOption, siteKey) => {
     checkForLoginMechanism(participant);
     const isParent = localStorage.getItem('isParent');
     document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks(isParent);
@@ -339,6 +339,7 @@ const updateUserSigninMechanism = (participant, siteKey) => {
             const body = document.getElementById('modalBody');
             header.innerHTML = `<h5>Change Login Mode</h5><button type="button" class="modal-close-btn" data-dismiss="modal" id="closeModal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
             template = `<div> <form id="formResponse2" method="post"> `
+            //TODO this ref
             if (participant[fieldMapping.signInMechansim] === 'phone') {
                 template +=  `<div class="form-group">
                             <label class="col-form-label search-label">Current Login</label>
@@ -349,6 +350,7 @@ const updateUserSigninMechanism = (participant, siteKey) => {
                             <input class="form-control" type="email" id="confirmEmail" placeholder="Confim Email"/>
                         </div>`
             }
+            //TODO this ref
             else if (participant[fieldMapping.signInMechansim] === 'password') {
                 template +=  `<div class="form-group">
                             <label class="col-form-label search-label">Current Login</label>

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -1,9 +1,8 @@
-import { renderNavBarLinks, dashboardNavBarLinks, removeActiveClass } from './navigationBar.js';
+import { dashboardNavBarLinks, removeActiveClass } from './navigationBar.js';
+import { allStates, closeModal, fieldValues, formatInputResponse, getImportantRows, getModalLabel, hideUneditableButtons, reloadParticipantData, renderReturnSearchResults, resetChanges, saveResponses, showSaveNoteInModal, suffixList, submitClickHandler, viewAuditHandler, viewParticipantSummary, } from './participantDetailsHelpers.js';
 import fieldMapping from './fieldToConceptIdMapping.js'; 
 import { renderParticipantHeader } from './participantHeader.js';
 import { getCurrentTimeStamp, getDataAttributes, showAnimation, hideAnimation, baseAPI } from './utils.js';
-import { renderParticipantSummary } from './participantSummary.js';
-import { renderLookupResultsTable, findParticipant } from './participantLookup.js';
 import { appState } from './stateManager.js';
 
 appState.setState({unsavedChangesTrack:{saveFlag: false, counter: 0}});
@@ -22,8 +21,9 @@ window.addEventListener('onload', (e) => {
     }, 15);
 })
 
+//TODO integrate Warren's code (fixing for Abhinav)
 const checkForLoginMechanism = (participant) => {
-    const isPhoneLogin = participant[fieldMapping.signInMechansim] === `phone`
+    const isPhoneLogin = participant?.[fieldMapping.signInMechansim] === `phone`;
     if (isPhoneLogin) {
         appState.setState({loginMechanism:{phone: true, email: false}})
         participant['Change Login Mode'] = 'Phone ☎️'
@@ -34,17 +34,17 @@ const checkForLoginMechanism = (participant) => {
         participant['Change Login Mode'] = 'Email 📧'
         participant['Change Login Email'] = participant[fieldMapping.accountEmail]
     }
-
 }
 
-export const renderParticipantDetails = (participant, adminSubjectAudit, changedOption, siteKey) => {
+export const renderParticipantDetails = async (participant, adminSubjectAudit, changedOption, siteKey) => {
     checkForLoginMechanism(participant);
-    const isParent = localStorage.getItem('isParent')
+    const isParent = localStorage.getItem('isParent');
     document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks(isParent);
     removeActiveClass('nav-link', 'active');
     document.getElementById('participantDetailsBtn').classList.add('active');
-    mainContent.innerHTML = render(participant);
+    mainContent.innerHTML = render(participant, changedOption);
     let originalHTML =  mainContent.innerHTML;
+    hideUneditableButtons(participant, changedOption);
     localStorage.setItem("participant", JSON.stringify(participant));
     viewAuditHandler(adminSubjectAudit);
     changeParticipantDetail(participant, adminSubjectAudit, changedOption, originalHTML, siteKey);
@@ -53,195 +53,71 @@ export const renderParticipantDetails = (participant, adminSubjectAudit, changed
     renderReturnSearchResults();
     updateUserSigninMechanism(participant, siteKey);
     updateUserLogin(participant, siteKey);
+    submitClickHandler(participant, changedOption, siteKey);
 }
 
-export const render = (participant) => {
-    const fieldValues = 
-        {       
-            353358909: 'Yes',
-            104430631: 'No',
-            612166858: 'Jr.',
-            255907182: 'Sr.',
-            226924545: 'I',
-            270793412: 'II',
-            959021713: 'III',
-            643664527: '2nd',
-            537892528: '3rd',
-            127547625: 'Phone',
-            869588347: 'Email'
-        }
-    const importantColumns = [ 
-        { field: fieldMapping.lName,
-            editable: true,
-            display: true } ,
-        { field: fieldMapping.fName,
-            editable: true,
-            display: true } ,
-         { field: fieldMapping.prefName,
-        editable: true,
-        display: true } ,
-         { field: fieldMapping.mName,
-        editable: true,
-        display: true } ,
-         { field: fieldMapping.suffix,
-        editable: true,
-        display: true } ,
-         { field: fieldMapping.birthMonth,
-        editable: true,
-        display: true } ,
-         { field: fieldMapping.birthDay,
-        editable: true,
-        display: true } ,
-         { field: fieldMapping.birthYear,
-        editable: true,
-        display: true } ,
-        { field: fieldMapping.cellPhone,
-        editable: true,
-        display: true },
-        { field: fieldMapping.canWeText,
-        editable: true,
-        display: true },
-        { field: fieldMapping.voicemailMobile,
-        editable: true,
-        display: true },
-         { field: fieldMapping.homePhone,
-        editable: true,
-        display: true } ,
-        { field: fieldMapping.voicemailHome,
-        editable: true,
-        display: true },
-        { field: fieldMapping.otherPhone,
-        editable: true,
-        display: true },
-        { field: fieldMapping.voicemailOther,
-        editable: true,
-        display: true },
-        { field: fieldMapping.email,
-        editable: true,
-        display: true },
-        { field: fieldMapping.email1,
-        editable: true,
-        display: true },
-        { field: fieldMapping.email2,
-        editable: true,
-        display: true },
-        { field: fieldMapping.address1,
-        editable: true,
-        display: true },
-        { field: fieldMapping.address2,
-        editable: true,
-        display: true },
-        { field: fieldMapping.city,
-        editable: true,
-        display: true },
-        { field: fieldMapping.state,
-        editable: true,
-        display: true },
-        { field: fieldMapping.zip,
-        editable: true,
-        display: true },
-        { field: 'Connect_ID',
-        editable: false,
-        display: true }
-    ];
-
-    const loginChangeInfoArray = [
-        { field: `Change Login Mode`,
-        editable: true,
-        display: true },
-        { field: `Change Login Email`,
-        editable: true,
-        display: appState.getState().loginMechanism.email },
-        { field: `Change Login Phone`,
-        editable: true,
-        display:  appState.getState().loginMechanism.phone }
-    ];
-
-    const userLoginEmail = appState.getState().userSession?.email ?? '';
-    const permDomains = /(nih.gov|norc.org)$/i;
-    permDomains.test(userLoginEmail.split('@')[1]) && importantColumns.push(...loginChangeInfoArray);
+export const render = (participant, changedOption) => {
+    const importantRows = getImportantRows(participant, changedOption);
 
     let template = `<div class="container">`
     if (!participant) {
         template +=` 
             <div id="root">
-            Please select a participant first!
+                Please select a participant first!
             </div>
         </div>
         `
     } else {
-        let conceptIdMapping = JSON.parse(localStorage.getItem('conceptIdMapping'));
+        const filteredImportantRows = importantRows.filter(row => row.display === true);
         template += `<div id="root" > 
                     <div id="alert_placeholder"></div>`
         template += renderParticipantHeader(participant);
-        template += `
-                        <div class="float-left">
-                            <button type="button" class="btn btn-primary" id="displaySearchResultsBtn">Back to Search</button>
-                        </div>
-                        
-                        <table class="table detailsTable"> <h4 style="text-align: center;"> Participant Details </h4>
-                            <thead style="position: sticky;" class="thead-dark"> 
-                            <tr>
-                                <th style="text-align: left; scope="col">Field</th>
-                                <th style="text-align: left; scope="col">Value</th>
-                                <th style="text-align: left; scope="col"></th>
-                            </thead>
-                        <tbody class="participantDetailTable">
-`
-                    const filteredImportantColumns = importantColumns.filter(x => x.display === true);
-                    filteredImportantColumns.forEach(x => template += `<tr class="detailedRow" style="text-align: left;"><th scope="row"><div class="mb-3">
-                    <label class="form-label">
-                    ${conceptIdMapping[x.field] && conceptIdMapping[x.field] ? 
-                        (   
-                            ((conceptIdMapping[x.field]['Variable Label'] || conceptIdMapping[x.field]['Variable Name']) === 'Text') ? 
-                                    'Do we have permission to text this number ?'
-                            : conceptIdMapping[x.field]['Variable Label'] || conceptIdMapping[x.field]['Variable Name'])
-                            : x.field}</label></div></th>
-                    <td style="text-align: left;">${participant[x.field] = (participant[x.field]) === undefined ? `` :  fieldValues[participant[x.field]] || participant[x.field]}</td> 
-                    <td style="text-align: left;">
-                        ${ x.editable && (x.field == 'Change Login Mode') ? `<button type="button" class="btn btn-success btn-custom" data-toggle="modal" data-target="#modalShowMoreData" id="switchSiginMechanism">Change</button>` 
-                        : 
-                        (participant[fieldMapping.signInMechansim] === `password` && x.field == 'Change Login Email') ? `<button type="button" class="btn btn-success btn-custom" data-toggle="modal" data-target="#modalShowMoreData" data-participantLoginUpdate='email' id="updateUserLogin">Update</button>` 
-                        : 
-                        (participant[fieldMapping.signInMechansim] === `phone` && x.field == 'Change Login Phone') ? `<button type="button" class="btn btn-success btn-custom" data-toggle="modal" data-target="#modalShowMoreData" data-participantLoginUpdate='phone' id="updateUserLogin">Update</button>` 
-                        :
-                        (x.editable && (participant[fieldMapping.verifiedFlag] !== (fieldMapping.verified || fieldMapping.cannotBeVerified || fieldMapping.duplicate)) )? 
-                        ` <a class="showMore" data-toggle="modal" data-target="#modalShowMoreData" 
-                            data-participantkey=${conceptIdMapping[x.field] && (conceptIdMapping[x.field] && conceptIdMapping[x.field]['Variable Label'] !== undefined) ? conceptIdMapping[x.field]['Variable Label'].replace(/\s/g, "") || conceptIdMapping[x.field]['Variable Name'].replace(/\s/g, "") : ""}
-                            data-participantconceptid=${x.field} data-participantValue=${formatInputResponse(participant[x.field])} name="modalParticipantData" 
-                            id=${x.field}>
-                            <button type="button" class="btn btn-primary btn-custom">Edit</button>`
-                        : `<button type="button" class="btn btn-secondary btn-custom" disabled>Edit</button>`
-                        }
-                    </a></td></tr>&nbsp;`)
-                      
-        template += `</tbody></table>
-        <br />
-                <div style="display:inline-block;">
-                    <button type="button" id="cancelChanges" class="btn btn-danger">Cancel Changes</button>
-                    &nbsp;
-                    <button type="submit" id="sendResponse" class="btn btn-primary" >Save Changes</button>
-                    &nbsp;
-                    <br />
-                </div>
-                </div>
-            </div>
+        template += `      
+            ${renderBackToSearchDivAndButton()}
+            ${renderCancelChangesAndSaveChangesButtons()}
+            ${renderDetailsTableHeader()}
         `;
-        template += ` <div class="modal fade" id="modalShowMoreData" data-keyboard="false" tabindex="-1" role="dialog" data-backdrop="static" aria-hidden="true">
-            <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
-                <div class="modal-content sub-div-shadow">
-                    <div class="modal-header" id="modalHeader"></div>
-                    <div class="modal-body" id="modalBody"></div>
-                </div>
+        filteredImportantRows.forEach(row => {
+            const cId = row.field;
+            const variableLabel = row.label;
+            const variableValue = participant[cId] === undefined ? '' :  fieldValues[participant[cId]] || participant[cId];
+            const participantValue = formatInputResponse(participant[cId]);
+            const participantSignInMechanism = participant[fieldMapping.signInMechansim];
+            const buttonToRender = getButtonToRender(row, participantSignInMechanism, variableLabel, cId, participantValue);
+            template += `
+                <tr class="detailedRow" style="text-align: left;">
+                    <th scope="row">
+                        <div class="mb-3">
+                            <label class="form-label">
+                                ${variableLabel}
+                            </label>
+                        </div>
+                    </th>
+                    <td style="text-align: left;" id="${cId}value">
+                        ${variableValue}
+                        <br>
+                        <br>
+                        <div id="${cId}note" style="display:none"></div>
+                    </td> 
+                    <td style="text-align: left;">
+                        ${buttonToRender}
+                    </td>
+                </tr>
+            `
+        });
+        template += `
+                    </tbody>
+                </table>
+                ${renderCancelChangesAndSaveChangesButtons()}
             </div>
-        </div>`
-     
+        </div>
+        `;
+        template += `${renderShowMoreDataModal()}`
     }
     return template;
 }
 
 const changeParticipantDetail = (participant, adminSubjectAudit, changedOption, originalHTML, siteKey) => {
-
     const a = Array.from(document.getElementsByClassName('detailedRow'));
     if (a) {
         a.forEach(element => {
@@ -251,132 +127,63 @@ const changeParticipantDetail = (participant, adminSubjectAudit, changedOption, 
             editRow && editRow.addEventListener('click', () => {
                 const header = document.getElementById('modalHeader');
                 const body = document.getElementById('modalBody');
-                header.innerHTML = `<h5>Edit</h5><button type="button" class="modal-close-btn" id="closeModal" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
-                let template = '<div>'
-                template += `
-                <form id="formResponse" method="post">  
-                <span><span id="fieldModified" data-fieldconceptid=${data.participantconceptid} data-fieldModified=${data.participantkey}>${removeCamelCase(data.participantkey)}</span> 
-                : <input required type="text" name="newValue" id="newValue" data-currentValue=${data.participantvalue} 
-                    value=${
-                            data.participantvalue === fieldMapping.yes ? `Yes`:
-                                        data.participantvalue === fieldMapping.no ? `No`:
-                                        data.participantvalue === `name="modalParticipantData"` ? `+` : ``} />
-                            <br >
-                            <span style="font-size: 12px;" id="showNote"><i></i></span>
-                            <br >
-                        <div style="display:inline-block;">
-                            <button type="submit" class="btn btn-danger" data-dismiss="modal" target="_blank">Cancel</button>
-                            <button type="submit" class="btn btn-primary" id="editModal" data-toggle="modal">Submit</button>
-                        </div>
-                    </form>
-                </div>`
+                const cId = data.participantconceptid;
+                const participantKey = data.participantkey;
+                const modalLabel = getModalLabel(participantKey);
+                const participantValue = data.participantvalue;
+                header.innerHTML = `
+                    <h5>Edit ${modalLabel}</h5>
+                    <button type="button" class="modal-close-btn" id="closeModal" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
+                let template = `
+                    <div>
+                        ${renderFormInModal(participant, changedOption, cId, participantKey, modalLabel, participantValue)}
+                    </div>`
                 body.innerHTML = template;
-                saveResponses(participant, adminSubjectAudit, changedOption, element);
-               // postEditedResponse(participant, adminSubjectAudit, changedOption, siteKey);
+                showSaveNoteInModal();
+                saveResponses(participant, adminSubjectAudit, changedOption, element, siteKey);
                 viewAuditHandler(adminSubjectAudit);
-                showSaveAlert();
-                resetChanges(participant, originalHTML, siteKey);  
-                showSaveNote();
-               // viewParticipantSummary(participant);          
+                resetChanges(participant, originalHTML, siteKey);   
             });
-
-        })
-    }
-    else {
-
-    }
-}
-
-const showSaveNote = () => {
-    const a = document.getElementById('newValue');
-    if (a) {
-        a.addEventListener('click', () => {
-            const b = document.getElementById('showNote');
-            b.innerHTML = `After 'Submit' you must scroll down and click 'Save Changes' at bottom of screen for your changes to be saved.`
         })
     }
 }
 
-const removeCamelCase = (participantKey) => {
-    let s = participantKey
-    s = s.replace(/([A-Z])/g, ' $1').trim()
-    return s;
-}
+const getButtonToRender = (row, participantSignInMechanism, variableLabel, cId, participantValue) => {
+    const editButton = `
+        <a class="showMore" 
+            data-toggle="modal" 
+            data-target="#modalShowMoreData"
+            data-participantkey="${variableLabel}"
+            data-participantconceptid="${cId}" 
+            data-participantValue="${participantValue}" 
+            name="modalParticipantData"
+            id="${cId}button">
+            <button type="button" class="btn btn-primary btn-custom">Edit</button>
+        </a>
+        `;
+    const changeLoginModeButton = `<button type="button" class="btn btn-primary btn-custom" data-toggle="modal" data-target="#modalShowMoreData" id="switchSiginMechanism">Change</button>`;
+    const updateLoginEmailButton = `<button type="button" class="btn btn-primary btn-custom" data-toggle="modal" data-target="#modalShowMoreData" data-participantLoginUpdate='email' id="updateUserLogin">Update</button>`;
+    const updateLoginPhoneButton = `<button type="button" class="btn btn-primary btn-custom" data-toggle="modal" data-target="#modalShowMoreData" data-participantLoginUpdate='phone' id="updateUserLogin">Update</button>`;
 
-const formatInputResponse = (participantValue) => {
-    let ptValue = ``
-    if (participantValue !== undefined) {
-        ptValue  = participantValue.toString().replace(/\s/g, "")
+    if (row.editable && cId === 'Change Login Mode') {
+        return changeLoginModeButton;
+    } else if (participantSignInMechanism === 'password' && cId === 'Change Login Email') {
+        return updateLoginEmailButton;
+    } else if (participantSignInMechanism === 'phone' && cId === 'Change Login Phone') {
+        return updateLoginPhoneButton;
+    } else {
+        return editButton;
     }
-    return ptValue;
-}
-
-// creates payload to be sent to backend and update the UI. Remaps the field name back to concept id along with new responses.
-const saveResponses = (participant, adminSubjectAudit, changedOption, editedElement) => {
-    let displayAuditHistory = {};
-    let conceptId = [];
-    const a = document.getElementById('formResponse')
-    a.addEventListener('submit', e => {
-        e.preventDefault()
-        // fieldModifiedData   
-        let fieldModifiedData = getDataAttributes(document.getElementById('fieldModified'));
-        conceptId.push(fieldModifiedData.fieldconceptid);
-        // new value
-        let newUpdatedValue = document.getElementById('newValue').value;
-        if (newUpdatedValue.toString().toUpperCase() === 'NO') {newUpdatedValue = fieldMapping.no}
-        if (newUpdatedValue.toString().toUpperCase() === 'YES') {newUpdatedValue = fieldMapping.yes}
-        changedOption[conceptId[conceptId.length - 1]] = newUpdatedValue;
-
-        // if a changed field is a date of birth field then we need to update full date of birth  
-        if ("795827569" in changedOption || "564964481" in changedOption || "544150384" in changedOption) {
-            let day = "795827569" in changedOption ?  changedOption["795827569"] : getDataAttributes(document.getElementById('795827569')).participantvalue;
-            let month = "564964481" in changedOption ? changedOption["564964481"] : getDataAttributes(document.getElementById('564964481')).participantvalue;
-            let year = "544150384" in changedOption ? changedOption["544150384"] : getDataAttributes(document.getElementById('544150384')).participantvalue;
-            conceptId.push("371067537");
-            changedOption[conceptId[conceptId.length - 1]] =  year.toString() + month.padStart(2, '0')+ day.padStart(2, '0') ;
-        }
-
-        // update changed field on UI
-        let updatedEditValue = editedElement.querySelectorAll("td")[0];
-        updatedEditValue.innerHTML = newUpdatedValue;
-        
-        ///////////////////////////////////////////////
-        // participant token
-        displayAuditHistory.token = participant.token;
-        // fieldModifiedData
-        let fieldChanged = getDataAttributes(document.getElementById('fieldModified'));
-        displayAuditHistory.fieldModified = fieldChanged.fieldmodified;
-        // currentValue
-        let currentValueData = getDataAttributes(document.getElementById('newValue'));
-        displayAuditHistory.currentvalue = currentValueData.currentvalue;
-        // newValue
-        displayAuditHistory.newValue = document.getElementById('newValue').value;
-        // timeStamp
-        let timeStampData =  getCurrentTimeStamp();
-        displayAuditHistory.timeStamp = timeStampData;
-        // comment
-        //displayAuditHistory.comment = document.getElementById('comment').value;
-        // userID
-        let userIdData = getCurrentTimeStamp();
-        displayAuditHistory.userId = userIdData;
-        // Source
-        let source = "Site Manager Dashboard";
-        displayAuditHistory.source = source;
-        adminSubjectAudit.push(displayAuditHistory);
-      
-    })
-
-}
+};
 
 // For alternate contact details. Would be updates once concept ids for alt details are ready
-
 const editAltContact = (participant, adminSubjectAudit) => {
     const a = document.getElementById('altContact');
     if (a) {
         a.addEventListener('click',  () => {
         altContactHandler(participant, adminSubjectAudit);
-    })
-}
+        })
+    }   
 }
 
 const altContactHandler = (participant, adminSubjectAudit) => {
@@ -385,7 +192,6 @@ const altContactHandler = (participant, adminSubjectAudit) => {
     header.innerHTML = `<h5>Alternate Contact Details</h5><button type="button" id="closeModal" class="modal-close-btn" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
     let template = '<div>'
     template += `
-
             <br />
             <span id='fieldName' data-fieldName='First Name'><strong>Name</strong></span> : <input type="text" name="newName" id="newName" data-currrentFName=${participant.Module1 && participant.Module1.ALTCONTACT1.ALTCONTACT1_FNAME} value=${participant.Module1 && participant.Module1.ALTCONTACT1.ALTCONTACT1_FNAME} />
             <br />
@@ -401,16 +207,15 @@ const altContactHandler = (participant, adminSubjectAudit) => {
             <br />
 
             <div style="display:inline-block;">
-                <button type="button" class="btn btn-primary" id="altDetailsSubmit">Submit</button>
                 <button type="submit" class="btn btn-danger" data-dismiss="modal" target="_blank">Cancel</button>
+                <button type="button" class="btn btn-primary" id="altDetailsSubmit">Submit</button>
             </div>
-
-   </div>`
+        </div>`
     body.innerHTML = template;
     saveAltResponse(adminSubjectAudit, participant);
     viewAuditHandler(adminSubjectAudit);
     viewParticipantSummary(participant)
-} 
+}
 
 const saveAltResponse = (adminSubjectAudit, participant) => {
     const a = document.getElementById('altDetailsSubmit')
@@ -455,8 +260,8 @@ const saveAltResponse = (adminSubjectAudit, participant) => {
 
         const module1 = {'token': participant.token, 'Module': changedModuleOption, 'timeStamp': timeStampData, 'userId': userIdData};
         adminSubjectAudit.push(module1);
-        const modalClose = document.getElementById('modalShowMoreData')
-        const closeButton = modalClose.querySelector('#closeModal').click()
+        
+        closeModal();
       
         let editedElement;
         const a = Array.from(document.getElementsByClassName('detaileAltRow'))
@@ -490,108 +295,43 @@ const saveAltResponse = (adminSubjectAudit, participant) => {
     })
 }
 
-/////// Helper Functions /////////
-
-const showSaveAlert = () => {
-    const a = document.getElementById('editModal');
-    a.addEventListener('click', e => {
-        let prevCounter =  appState.getState().unsavedChangesTrack.counter
-        appState.setState({unsavedChangesTrack:{saveFlag: false, counter: prevCounter+1}})
-        const modalClose = document.getElementById('modalShowMoreData')
-        const closeButton = modalClose.querySelector('#closeModal').click()
-    })
-   
-}
-
-const resetChanges = (participant, originalHTML, siteKey) => {
-    const a = document.getElementById("cancelChanges");
-    let template = '';
-    a.addEventListener("click", () => {
-        if ( appState.getState().unsavedChangesTrack.saveFlag === false ) {
-            mainContent.innerHTML = originalHTML;
-            renderParticipantDetails(participant, [], {}, siteKey);
-            appState.setState({unsavedChangesTrack:{saveFlag: false, counter: 0}})
-            let alertList = document.getElementById('alert_placeholder');
-            // throws an alert when canncel changes button is clicked
-            template += `<div class="alert alert-warning alert-dismissible fade show" role="alert">
-                            Changes cancelled.
-                            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                         </div>`
-            alertList.innerHTML = template;
-        }
-        else {  
-            alert('No changes to save or cancel');
-          
-        }
-    })
-    
-}
-
-
-const postEditedResponse = (participant, adminSubjectAudit, changedOption, siteKey) => {
-
-    const a = document.getElementById('sendResponse');
-    a.addEventListener('click', () => {
-        changedOption['token'] = participant.token;
-        clickHandler(adminSubjectAudit, changedOption, siteKey);
-    })
-}
-
-
-
 // async-await function to make HTTP POST request
-async function clickHandler(adminSubjectAudit, updatedOptions, siteKey)  {
+async function signInMechanismClickHandler(adminSubjectAudit, updatedOptions, siteKey)  {
     showAnimation();
    
     const updateParticpantPayload = {
         "data": [updatedOptions]
     }
 
-    const response = await (await fetch(`${baseAPI}/dashboard?api=updateParticipantData`,{
+    const response = await fetch(`${baseAPI}/dashboard?api=updateParticipantData`,{
         method:'POST',
         body: JSON.stringify(updateParticpantPayload),
         headers:{
             Authorization:"Bearer "+siteKey,
             "Content-Type": "application/json"
             }
-        }))
-        hideAnimation();
-        if (response.status === 200) {
-            document.getElementById('loadingAnimation').style.display = 'none';
-            appState.setState({unsavedChangesTrack:{saveFlag: true, counter: 0}})
-            let lastModifiedHolder;
-            adminSubjectAudit.length === 0 ? "" : lastModifiedHolder = adminSubjectAudit[adminSubjectAudit.length - 1]
-            let alertList = document.getElementById("alert_placeholder");
-            let template = ``;
-            template += `
-                    <div class="alert alert-success alert-dismissible fade show" role="alert">
-                    Participant detail updated!
-                      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                    </div>`;
-            alertList.innerHTML = template;
-            return true;
-            // let a = document.getElementById('modifiedId')
-            // a.innerHTML = 'Placeholder for User id' + ' @ ' + lastModifiedHolder.timeStamp;
-         }
-           else { 
-               (alert('Error'))
-        }
- }
-
-// Admin audit displaying logs
- const viewAuditHandler = (adminSubjectAudit) => {
-    const a = document.getElementById('adminAudit');
-    if (a) {
-        a.addEventListener('click',  () => {
-            buttonAuditHandler(adminSubjectAudit);
-    })
+    });
+    hideAnimation();
+    if (response.status === 200) {
+        document.getElementById('loadingAnimation').style.display = 'none';
+        appState.setState({unsavedChangesTrack:{saveFlag: true, counter: 0}})
+        let lastModifiedHolder;
+        adminSubjectAudit.length === 0 ? "" : lastModifiedHolder = adminSubjectAudit[adminSubjectAudit.length - 1]
+        let alertList = document.getElementById("alert_placeholder");
+        let template = ``;
+        template += `
+                <div class="alert alert-success alert-dismissible fade show" role="alert">
+                Participant detail updated!
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                </div>`;
+        alertList.innerHTML = template;
+        return true;
+    } else { 
+        alert('Error');
     }
 }
-
 
 const updateUserSigninMechanism = (participant, siteKey) => {
     const switchSiginButton = document.getElementById('switchSiginMechanism');
@@ -636,7 +376,7 @@ const updateUserSigninMechanism = (participant, siteKey) => {
     }
    }
 // updates existing email or phone
-   const updateUserLogin = (participant, siteKey) => {
+const updateUserLogin = (participant, siteKey) => {
     const switchSiginButton = document.getElementById('updateUserLogin');
     let updateFlag = ``
     let template = ``
@@ -681,8 +421,7 @@ const updateUserSigninMechanism = (participant, siteKey) => {
             processSwitchSigninMechanism(participant, siteKey, updateFlag);
         })
     }
-   }
-
+}
 
 const processSwitchSigninMechanism = (participant, siteKey, flag) => {
     document.getElementById('formResponse2') && document.getElementById('formResponse2').addEventListener('submit', e => {
@@ -725,7 +464,6 @@ const processSwitchSigninMechanism = (participant, siteKey, flag) => {
     })
 };
 
-
 // async-await function to make HTTP POST request
 const switchSigninMechanismHandler = async (switchPackage, siteKey, changedOption) =>  {
     showAnimation();
@@ -744,7 +482,7 @@ const switchSigninMechanismHandler = async (switchPackage, siteKey, changedOptio
         }))
         hideAnimation();
         if (response.status === 200) {
-            clickHandler({}, changedOption, siteKey);
+            signInMechanismClickHandler({}, changedOption, siteKey);
             let alertList = document.getElementById("alert_placeholder");
             let template = ``;
             template += `
@@ -755,8 +493,9 @@ const switchSigninMechanismHandler = async (switchPackage, siteKey, changedOptio
                             </button>
                     </div>`;
             alertList.innerHTML = template;
-            const modalClose = document.getElementById('modalShowMoreData');
-            const closeButton = modalClose.querySelector('#closeModal').click();
+            
+            closeModal();
+            
             const UpdateRowStatus = Array.from(document.getElementsByClassName('detailedRow'));
             if (switchPackage.flag === "updatePhone" || switchPackage.flag === "updateEmail") {
                 let updateStatus = UpdateRowStatus[25].querySelectorAll("td")[0];
@@ -795,50 +534,161 @@ const switchSigninMechanismHandler = async (switchPackage, siteKey, changedOptio
             body.innerHTML = `Operation Unsuccessful!`;
             return false;
         }
- }
-
- const reloadParticipantData = async (token, siteKey) => {
-    showAnimation();
-    const query = `token=${token}`
-    const reloadedParticpant = await findParticipant(query);
-    mainContent.innerHTML = render(reloadedParticpant.data[0]);
-    renderParticipantDetails(reloadedParticpant.data[0], [],  {}, siteKey);
-    hideAnimation();
-    }
-
- const buttonAuditHandler = (adminSubjectAudit) => {
-        const header = document.getElementById('modalHeader');
-        const body = document.getElementById('modalBody');
-        header.innerHTML = `<h5>Audit History</h5><button type="button" class="modal-close-btn" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
-        let template = '<div>'
-        adminSubjectAudit.length === 0 ? (
-            template+= `<span> No changes to show </span></div>`
-        ) : (
-        adminSubjectAudit.map(element => {
-            let JSONresponse = JSON.stringify(element);
-            template += `<span>
-               ${JSONresponse};
-            </span>
-        </div>`
-        }))
-       
-        body.innerHTML = template;
-} 
-
-
-const viewParticipantSummary = (participant) => {
-    const a = document.getElementById('viewSummary');
-    if (a) {
-        a.addEventListener('click',  () => {  
-            renderParticipantSummary(participant);
-        })
-    }
 }
 
-const renderReturnSearchResults = () => {
-    const a = document.getElementById('displaySearchResultsBtn');
-    if (a) {
-        a.addEventListener('click', () => {
-            renderLookupResultsTable();
-        })
-}}
+const renderBackToSearchDivAndButton = () => {
+    return `
+        <div class="float-left">
+            <button type="button" class="btn btn-primary" id="displaySearchResultsBtn">Back to Search</button>    
+        </div>
+        
+    `;
+};
+
+const renderDetailsTableHeader = () => {
+    return `
+        <table class="table detailsTable"> <h4 style="text-align: center;"> Participant Details </h4>
+            <thead style="position: sticky;" class="thead-dark"> 
+                <tr>
+                    <th style="text-align: left; scope="col">Field</th>
+                    <th style="text-align: left; scope="col">Value</th>
+                    <th style="text-align: left; scope="col"></th>
+                </tr>
+            </thead>
+        <tbody class="participantDetailTable">
+    `;
+};
+
+const renderFormInModal = (participant, changedOption, cId, participantKey, modalLabel, participantValue) => {
+    const textFieldMappingsArray = getImportantRows(participant, changedOption)
+        .filter(row => row.editable && (row.validationType == 'text' || row.validationType == 'phoneNumber' || row.validationType == 'email' || row.validationType == 'address' || row.validationType == 'year' || row.validationType == 'zip'))
+        .map(row => row.field);
+    const permissionSelector = getImportantRows(participant, changedOption)
+        .filter(row => row.editable && (row.validationType == 'permissionSelector'))
+        .map(row => row.field);
+
+    const renderPermissionSelector = permissionSelector.includes(parseInt(cId));
+    const renderText = textFieldMappingsArray.includes(parseInt(cId));
+    const renderDay = cId == fieldMapping.birthDay;
+    const renderMonth = cId == fieldMapping.birthMonth;
+    const renderState = cId == fieldMapping.state;
+    const renderSuffix = cId == fieldMapping.suffix;
+
+    return `
+        <form id="formResponse" method="post">
+            <span id="fieldModified" data-fieldconceptid=${cId} data-fieldModified=${participantKey}>
+                ${modalLabel}:
+            </span>
+            ${renderDay ? renderDaySelector(participantValue) : ''}
+            ${renderMonth ? renderMonthSelector(participantValue) : ''}
+            ${renderPermissionSelector ? renderTextVoicemailPermissionSelector(participantValue) : ''}
+            ${renderState ? renderStateSelector(participantValue) : ''}
+            ${renderSuffix ? renderSuffixSelector(participant, participantValue) : ''}
+            ${renderText ? renderTextInputBox(participantValue) : ''}
+            <br/>
+            <span id="showError"></span>
+            <span style="font-size: 12px;" id="showNote"><i></i></span>
+            <br/>
+            <div style="display:inline-block;">
+                <button type="submit" class="btn btn-danger" data-dismiss="modal" target="_blank">Cancel</button>
+                &nbsp;
+                <button type="submit" class="btn btn-primary" id="editModal" data-toggle="modal">Submit</button>
+            </div>
+        </form>
+    `;
+};
+
+const renderShowMoreDataModal = () => {
+    return `
+        <div class="modal fade" id="modalShowMoreData" tabindex="-1" role="dialog" aria-hidden="true">
+            <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+                <div class="modal-content sub-div-shadow">
+                    <div class="modal-header" id="modalHeader"></div>
+                    <div class="modal-body" id="modalBody"></div>
+                </div>
+            </div>
+        </div>
+    `;
+};
+
+const renderCancelChangesAndSaveChangesButtons = () => {
+    return `
+        <div class="float-right" style="display:inline-block;">
+            <button type="button" id="cancelChanges" class="btn btn-danger">Cancel Changes</button>
+            &nbsp;
+            <button type="submit" id="updateMemberData" class="updateMemberData btn btn-primary">Save Changes</button>
+        </div>
+        </br>
+        </br>
+    `;
+};
+
+const renderDaySelector = (participantValue) => {
+    let options = '';
+    for(let i = 1; i <= 31; i++){
+        options += `<option class="option-dark-mode" value="${i.toString().padStart(2, '0')}">${i.toString().padStart(2, '0')}</option>`
+    }
+    return `
+        <select name="newValue" id="newValue" data-currentValue=${participantValue}>
+            ${options}
+        </select>
+    `;
+};
+
+const renderMonthSelector = (participantValue) => {
+    let options = '';
+    for(let i = 1; i <= 12; i++){
+        options += `<option class="option-dark-mode" value="${i.toString().padStart(2, '0')}">${i.toString().padStart(2, '0')}</option>`
+    }
+    return `
+        <select name="newValue" id="newValue" data-currentValue=${participantValue}>
+            ${options}
+        </select>
+    `;
+};
+
+const renderTextVoicemailPermissionSelector = (participantValue) => {
+        const options = `
+                <option class="option-dark-mode" value="">-- Select --</option>
+                <option class="option-dark-mode" value="${fieldMapping.yes}">Yes</option>
+                <option class="option-dark-mode" value="${fieldMapping.no}">No</option>`;
+        return `
+            <select name="newValue" id="newValue" data-currentValue=${participantValue}>
+                ${options}
+            </select>
+    `;
+};
+
+const renderStateSelector = (participantValue) => {
+    let options = '';
+    for(const state in allStates){
+        options += `<option class="option-dark-mode" value="${state}">${state}</option>`
+    }
+    return `
+        <select name="newValue" id="newValue" data-currentValue=${participantValue}>
+            ${options}
+        </select>
+    `;
+};
+
+const renderTextInputBox = (participantValue) => {
+    return `
+        <input type="text" name="newValue" id="newValue" data-currentValue=${participantValue}>
+    `;
+};
+
+const renderSuffixSelector = (participant, participantValue) => {
+    return `
+        <select style="max-width:200px; margin-left:0px;" name="newValue" id="newValue" data-currentValue=${participantValue}>
+            <option value="">-- Select --</option>
+            <option value="612166858" ${participant[fieldMapping.suffix] ? (suffixList[participant[fieldMapping.suffix]] == 0 ? 'selected':'') : ''}>Jr.</option>
+            <option value="255907182" ${participant[fieldMapping.suffix] ? (suffixList[participant[fieldMapping.suffix]] == 1 ? 'selected':'') : ''}>Sr.</option>
+            <option value="226924545" ${participant[fieldMapping.suffix] ? (suffixList[participant[fieldMapping.suffix]] == 2 ? 'selected':'') : ''}>I</option>
+            <option value="270793412" ${participant[fieldMapping.suffix] ? (suffixList[participant[fieldMapping.suffix]] == 3 ? 'selected':'') : ''}>II</option>
+            <option value="959021713" ${participant[fieldMapping.suffix] ? (suffixList[participant[fieldMapping.suffix]] == 4 ? 'selected':'') : ''}>III</option>
+            <option value="643664527" ${participant[fieldMapping.suffix] ? (suffixList[participant[fieldMapping.suffix]] == 5 ? 'selected':'') : ''}>2nd</option>
+            <option value="537892528" ${participant[fieldMapping.suffix] ? (suffixList[participant[fieldMapping.suffix]] == 6 ? 'selected':'') : ''}>3rd</option>
+        </select>
+        `
+};
+  

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -112,7 +112,7 @@ const isPhoneNumberInForm = (participant, changedOption, fieldMappingKey) => {
 };
 
 export const getImportantRows = (participant, changedOption) => {
-    const isParticipantVerified = participant[fieldMapping.verifiedFlag] == fieldMapping.verified;
+    const isParticipantVerified = participant[fieldMapping.verifiedFlag] === fieldMapping.verified;
     const isCellPhonePresent = isPhoneNumberInForm(participant, changedOption, fieldMapping.cellPhone);
     const isHomePhonePresent = isPhoneNumberInForm(participant, changedOption, fieldMapping.homePhone);
     const isOtherPhonePresent = isPhoneNumberInForm(participant, changedOption, fieldMapping.otherPhone);
@@ -318,6 +318,10 @@ export const getImportantRows = (participant, changedOption) => {
 
 /**
  * Determine whether a phone number is present in the form or in the changed options.
+ * A phone number is present if:
+ *  - it is present in the participant object or the changedOption object
+ *  - AND it is not an empty string in the changedOption object (empty string in changedOption means the user is trying to delete the phone number)
+ *  - AND the conceptId is not the same as the phoneType (conceptId is the field name being changed, phoneType is the field being checked see: getRequiredField())
  * This is used for validating phone number updates:
  * If no number is present, require a phone number before allowing user to submit the update
  * If a number is present, allow user to submit the update

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -3,7 +3,7 @@ import { render, renderParticipantDetails } from './participantDetails.js';
 import { findParticipant, renderLookupResultsTable } from './participantLookup.js';
 import { renderParticipantSummary } from './participantSummary.js';
 import { appState } from './stateManager.js';
-import { baseAPI, getCurrentTimeStamp, getDataAttributes, getIdToken, hideAnimation, showAnimation, getLoggedInUserForHistory } from './utils.js';
+import { baseAPI, getCurrentTimeStamp, getDataAttributes, getIdToken, hideAnimation, showAnimation } from './utils.js';
 
 export const allStates = {
     "Alabama":1,
@@ -846,10 +846,7 @@ export const viewParticipantSummary = (participant) => {
  */
 export const submitClickHandler = async (participant, changedOption, siteKey) => {
     const isParticipantVerified = participant[fieldMapping.verifiedFlag] == fieldMapping.verified;
-    let adminEmail = '';
-    if (isParticipantVerified) {
-        adminEmail = await fetchUpdatingAdminEmailAddress();
-    }
+    const adminEmail = appState.getState().userSession?.email ?? '';
     const submitButtons = document.getElementsByClassName('updateMemberData');
     for (const button of submitButtons) {
         button.addEventListener('click', async (e) => {
@@ -1022,16 +1019,6 @@ const populateUserHistoryMap = (existingData, adminEmail) => {
 
     return userHistoryMap;
 };
-
-export const fetchUpdatingAdminEmailAddress = async () => {
-    try {
-      const email = await getLoggedInUserForHistory();
-      return email;
-    } catch (error) {
-      console.error('Failed to fetch updating admim user\'s email:', error);
-      return '';
-    }
-}
 
 export const postUserDataUpdate = async (changedUserData) => {
     try {

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -360,49 +360,74 @@ const getIsRequiredField = (participant, changedOption, newValueElement, concept
  * @returns - user-friendly label for the modal
  */
 export const getModalLabel = (participantKey) => {
-    switch (participantKey) {
-        case 'LastName':
-            return 'Last Name';
-        case 'FirstName':
-            return 'First Name';
-        case 'MiddleName':
-            return 'Middle Name';
-        case 'PreferredName':
-            return 'Preferred Name';
-        case 'BirthMonth':
-            return 'Birth Month';
-        case 'BirthDay':
-            return 'Birth Day';
-        case 'BirthYear':
-            return 'Birth Year';
-        case 'Mobilephone':
-            return 'Mobile Phone';
-        case 'Text':
-            return 'Do we have permission to text this number';
-        case 'Mobilevoicemail':
-            return 'Do we have permission to leave a voicemail at this number';
-        case 'Homephone':
-            return 'Home Phone';
-        case 'Homevoicemail':
-            return 'Do we have permission to leave a voicemail at this number';
-        case 'Otherphone':
-            return 'Other Phone';
-        case 'Othervoicemail':
-            return 'Do we have permission to leave a voicemail at this number';
-        case 'Preferredemail':
-            return 'Preferred Email';
-        case 'Additionalemail1':
-            return 'Additional Email 1';
-        case 'Additionalemail2':
-            return 'Additional Email 2';
-        case 'Addressline1':
-            return 'Address Line 1';
-        case 'Addressline2':
-            return 'Address Line 2';
-        default:
-            return participantKey;
+    const labels = {
+        LastName: 'Last Name',
+        FirstName: 'First Name',
+        MiddleName: 'Middle Name',
+        PreferredName: 'Preferred Name',
+        BirthMonth: 'Birth Month',
+        BirthDay: 'Birth Day',
+        BirthYear: 'Birth Year',
+        Mobilephone: 'Mobile Phone',
+        Text: 'Do we have permission to text this number',
+        Mobilevoicemail: 'Do we have permission to leave a voicemail at this number',
+        Homephone: 'Home Phone',
+        Homevoicemail: 'Do we have permission to leave a voicemail at this number',
+        Otherphone: 'Other Phone',
+        Othervoicemail: 'Do we have permission to leave a voicemail at this number',
+        Preferredemail: 'Preferred Email',
+        Additionalemail1: 'Additional Email 1',
+        Additionalemail2: 'Additional Email 2',
+        Addressline1: 'Address Line 1',
+        Addressline2: 'Address Line 2',
     };
+
+    return labels[participantKey] || participantKey;
 };
+// export const getModalLabel = (participantKey) => {
+//     switch (participantKey) {
+//         case 'LastName':
+//             return 'Last Name';
+//         case 'FirstName':
+//             return 'First Name';
+//         case 'MiddleName':
+//             return 'Middle Name';
+//         case 'PreferredName':
+//             return 'Preferred Name';
+//         case 'BirthMonth':
+//             return 'Birth Month';
+//         case 'BirthDay':
+//             return 'Birth Day';
+//         case 'BirthYear':
+//             return 'Birth Year';
+//         case 'Mobilephone':
+//             return 'Mobile Phone';
+//         case 'Text':
+//             return 'Do we have permission to text this number';
+//         case 'Mobilevoicemail':
+//             return 'Do we have permission to leave a voicemail at this number';
+//         case 'Homephone':
+//             return 'Home Phone';
+//         case 'Homevoicemail':
+//             return 'Do we have permission to leave a voicemail at this number';
+//         case 'Otherphone':
+//             return 'Other Phone';
+//         case 'Othervoicemail':
+//             return 'Do we have permission to leave a voicemail at this number';
+//         case 'Preferredemail':
+//             return 'Preferred Email';
+//         case 'Additionalemail1':
+//             return 'Additional Email 1';
+//         case 'Additionalemail2':
+//             return 'Additional Email 2';
+//         case 'Addressline1':
+//             return 'Address Line 1';
+//         case 'Addressline2':
+//             return 'Address Line 2';
+//         default:
+//             return participantKey;
+//     };
+// };
 
 export const hideUneditableButtons = (participant, changedOption) => {
     const importantRows = getImportantRows(participant, changedOption);
@@ -432,9 +457,9 @@ export const removeCamelCase = (participantKey) => {
 };
 
 export const renderReturnSearchResults = () => {
-    const a = document.getElementById('displaySearchResultsBtn');
-    if (a) {
-        a.addEventListener('click', () => {
+    const searchResultsButton = document.getElementById('displaySearchResultsBtn');
+    if (searchResultsButton) {
+        searchResultsButton.addEventListener('click', () => {
             renderLookupResultsTable();
         })
 }};
@@ -1033,7 +1058,7 @@ export const postUserDataUpdate = async (changedUserData) => {
         });
 
         if (!response.ok) { 
-            const error = (response.status + ": " + (await response.json()).message) || response.status;
+            const error = (response.status + ": " + (await response.json()).message);
             throw new Error(error);
         }
         

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -1,0 +1,1057 @@
+import fieldMapping from './fieldToConceptIdMapping.js';
+import { render, renderParticipantDetails } from './participantDetails.js';
+import { findParticipant, renderLookupResultsTable } from './participantLookup.js';
+import { renderParticipantSummary } from './participantSummary.js';
+import { appState } from './stateManager.js';
+import { baseAPI, getCurrentTimeStamp, getDataAttributes, getIdToken, hideAnimation, showAnimation, getLoggedInUserForHistory } from './utils.js';
+
+export const allStates = {
+    "Alabama":1,
+    "Alaska":2,
+    "Arizona":3,
+    "Arkansas":4,
+    "California":5,
+    "Colorado":6,
+    "Connecticut":7,
+    "Delaware":8,
+    "District of Columbia": 9,
+    "Florida":10,
+    "Georgia":11,
+    "Hawaii":12,
+    "Idaho":13,
+    "Illinois":14,
+    "Indiana":15,
+    "Iowa":16,
+    "Kansas":17,
+    "Kentucky":18,
+    "Louisiana":19,
+    "Maine":20,
+    "Maryland":21,
+    "Massachusetts":22,
+    "Michigan":23,
+    "Minnesota":24,
+    "Mississippi":25,
+    "Missouri":26,
+    "Montana":27,
+    "Nebraska":28,
+    "Nevada":29,
+    "New Hampshire":30,
+    "New Jersey":31,
+    "New Mexico":32,
+    "New York":33,
+    "North Carolina":34,
+    "North Dakota":35,
+    "Ohio":36,
+    "Oklahoma":37,
+    "Oregon":38,
+    "Pennsylvania":39,
+    "Rhode Island":40,
+    "South Carolina":41,
+    "South Dakota":42,
+    "Tennessee":43,
+    "Texas":44,
+    "Utah":45,
+    "Vermont":46,
+    "Virginia":47,
+    "Washington":48,
+    "West Virginia":49,
+    "Wisconsin":50,
+    "Wyoming":51,
+    "NA": 52
+}
+
+const buttonAuditHandler = (adminSubjectAudit) => {
+    const header = document.getElementById('modalHeader');
+    const body = document.getElementById('modalBody');
+    header.innerHTML = `<h5>Audit History</h5><button type="button" class="modal-close-btn" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
+    let template = '<div>'
+    adminSubjectAudit.length === 0 ? (
+        template+= `<span> No changes to show </span></div>`
+    ) : (
+    adminSubjectAudit.map(element => {
+        let JSONresponse = JSON.stringify(element);
+        template += `<span>
+            ${JSONresponse};
+        </span>
+    </div>`
+    }))
+    
+    body.innerHTML = template;
+}
+
+export const closeModal = () => {
+    const modalClose = document.getElementById('modalShowMoreData');
+    modalClose.querySelector('#closeModal').click();
+};
+
+export const fieldValues = 
+    {       
+        353358909: 'Yes',
+        104430631: 'No',
+        612166858: 'Jr.',
+        255907182: 'Sr.',
+        226924545: 'I',
+        270793412: 'II',
+        959021713: 'III',
+        643664527: '2nd',
+        537892528: '3rd',
+        127547625: 'Phone',
+        869588347: 'Email'
+    }
+
+export const formatInputResponse = (participantValue) => {
+    let ptValue = '';
+    if (participantValue !== undefined) {
+        ptValue  = participantValue.toString().replace(/\s/g, "")
+    }
+    return ptValue;
+};
+
+const isPhoneNumberInForm = (participant, changedOption, fieldMappingKey) => {
+    return !!(participant && participant[fieldMappingKey]) || !!(changedOption && changedOption[fieldMappingKey]);
+};
+
+export const getImportantRows = (participant, changedOption) => {
+    const isParticipantVerified = participant[fieldMapping.verifiedFlag] == fieldMapping.verified;
+    const isCellPhonePresent = isPhoneNumberInForm(participant, changedOption, fieldMapping.cellPhone);
+    const isHomePhonePresent = isPhoneNumberInForm(participant, changedOption, fieldMapping.homePhone);
+    const isOtherPhonePresent = isPhoneNumberInForm(participant, changedOption, fieldMapping.otherPhone);
+    const importantRowsArray = [ 
+        { field: fieldMapping.lName,
+            label: 'Last Name',
+            editable: true,
+            display: true,
+            validationType: 'text',
+            isRequired: true
+        },
+        { field: fieldMapping.fName,
+            label: 'First Name',
+            editable: true,
+            display: true,
+            validationType: 'text',
+            isRequired: true
+        },
+        { field: fieldMapping.prefName,
+            label: 'Preferred Name',
+            editable: true,
+            display: true,
+            validationType: 'text',
+            isRequired: false
+        },
+        { field: fieldMapping.mName,
+            label: 'Middle Name',
+            editable: true,
+            display: true,
+            validationType: 'text',
+            isRequired: false
+        },
+        { field: fieldMapping.suffix,
+            label: 'Suffix',
+            editable: true,
+            display: true,
+            validationType: 'suffix',
+            isRequired: false
+        },
+        { field: fieldMapping.cellPhone,
+            label: 'Cell Phone',
+            editable: true,
+            display: true,
+            validationType: 'phoneNumber',
+            isRequired: false
+        },
+        { field: fieldMapping.canWeText,
+            label: 'Can we text your mobile phone?',
+            editable: isCellPhonePresent,
+            display: true,
+            validationType: 'permissionSelector',
+            isRequired: false
+        },
+        { field: fieldMapping.voicemailMobile,
+            label: 'Can we leave a voicemail at your mobile phone number?',
+            editable: isCellPhonePresent,
+            display: true,
+            validationType: 'permissionSelector',
+            isRequired: false
+        },
+        { field: fieldMapping.homePhone,
+            label: 'Home Phone',
+            editable: true,
+            display: true,
+            validationType: 'phoneNumber',
+            isRequired: false
+        },
+        { field: fieldMapping.voicemailHome,
+            label: 'Can we leave a voicemail at your home phone number?',
+            editable: isHomePhonePresent,
+            display: true,
+            validationType: 'permissionSelector',
+            isRequired: false
+        },
+        { field: fieldMapping.otherPhone,
+            label: 'Other Phone',
+            editable: true,
+            display: true,
+            validationType: 'phoneNumber',
+            isRequired: false
+        },
+        { field: fieldMapping.voicemailOther,
+            label: '   Can we leave a voicemail at your other phone number?',
+            editable: isOtherPhonePresent,
+            display: true,
+            validationType: 'permissionSelector',
+            isRequired: false
+        },
+        { field: fieldMapping.email,
+            label: 'Preferred Email',
+            editable: true,
+            display: true,
+            validationType: 'email',
+            isRequired: true
+        },
+        { field: fieldMapping.email1,
+            label: 'Additional Email 1',
+            editable: true,
+            display: true,
+            validationType: 'email',
+            isRequired: false
+        },
+        { field: fieldMapping.email2,
+            label: 'Additional Email 2',
+            editable: true,
+            display: true,
+            validationType: 'email',
+            isRequired: false
+        },
+        { field: fieldMapping.address1,
+            label: 'Address Line 1',
+            editable: true,
+            display: true,
+            validationType: 'address',
+            isRequired: true
+        },
+        { field: fieldMapping.address2,
+            label: 'Address Line 2',
+            editable: true,
+            display: true,
+            validationType: 'address',
+            isRequired: false
+        },
+        { field: fieldMapping.city,
+            label: 'City',
+            editable: true,
+            display: true,
+            validationType: 'text',
+            isRequired: true
+        },
+        { field: fieldMapping.state,
+            label: 'State',
+            editable: true,
+            display: true,
+            validationType: 'state',
+            isRequired: true
+        },
+        { field: fieldMapping.zip,
+            label: 'Zip',
+            editable: true,
+            display: true,
+            validationType: 'zip',
+            isRequired: true
+        },
+        { field: fieldMapping.birthMonth,
+            label: 'Birth Month',
+            editable: !isParticipantVerified,
+            display: !isParticipantVerified,
+            validationType: 'month',
+            isRequired: true
+        },
+        { field: fieldMapping.birthDay,
+            label: 'Birth Day',
+            editable: !isParticipantVerified,
+            display: !isParticipantVerified,
+            validationType: 'day',
+            isRequired: true
+        },
+        { field: fieldMapping.birthYear,
+            label: 'Birth Year',
+            editable: !isParticipantVerified,
+            display: !isParticipantVerified,
+            validationType: 'year',
+            isRequired: true
+        } ,
+        { field: 'Connect_ID',
+            label: 'Connect ID',
+            editable: false,
+            display: true,
+            validationType: 'none',
+            isRequired: true
+        },
+        { field: `Change Login Mode`,
+            label: 'Change Login Mode',
+            editable: true,
+            display: true,
+            validationType: 'none'
+        },
+    ];
+
+    const loginChangeInfoArray = [
+        { field: `Change Login Email`,
+            label: 'Change Login Email',
+            editable: true,
+            display: appState.getState().loginMechanism.email,
+            validationType: 'none'
+        },
+        { field: `Change Login Phone`,
+            label: 'Change Login Phone',
+            editable: true,
+            display:  appState.getState().loginMechanism.phone,
+            validationType: 'none'
+        }
+    ];
+
+    const userLoginEmail = appState.getState().userSession?.email ?? '';
+    console.log(appState.getState().loginMechanism.email);
+    console.log(appState.getState().loginMechanism.phone);
+    console.log(appState.getState().userSession?.email);
+    console.log('userLoginEmail', userLoginEmail);
+    const permDomains = /(nih.gov|norc.org)$/i;
+    permDomains.test(userLoginEmail.split('@')[1]) && importantRowsArray.push(...loginChangeInfoArray);
+
+    return importantRowsArray; 
+};
+
+/**
+ * Determine whether a phone number is present in the form or in the changed options.
+ * This is used for validating phone number updates:
+ * If no number is present, require a phone number before allowing user to submit the update
+ * If a number is present, allow user to submit the update
+ */
+function isPhoneNumberPresent(participant, changedOption, conceptId, phoneType) {
+    return (participant[phoneType] || changedOption[phoneType]) && changedOption[phoneType] !== '' && conceptId != phoneType;
+}
+
+/**
+ * Get whether a field is required or not
+ * Automatically required fields: fName, lName, birthMonth, birthYear, birthDay, prefEmail, addressLine1, city, state, zip.
+ * Make sure automatically required fields are present
+ * Additional requirement: at least one phone number must be present.
+ * If user is editing phone numbers, don't allow all of them to be empty (make at least one required)
+ */
+const getIsRequiredField = (participant, changedOption, newValueElement, conceptId) => {
+    const isRequiredFieldArray = getImportantRows(participant, changedOption)
+        .filter(row => row.isRequired === true)
+        .map(row => row.field);
+
+    if (isRequiredFieldArray.includes(parseInt(conceptId))) {
+        return true;
+    };
+
+    if (!newValueElement.value && (conceptId == fieldMapping.cellPhone || conceptId == fieldMapping.homePhone || conceptId == fieldMapping.otherPhone)) {
+        const isCellPhonePresent = isPhoneNumberPresent(participant, changedOption, conceptId, fieldMapping.cellPhone);
+        const isHomePhonePresent = isPhoneNumberPresent(participant, changedOption, conceptId, fieldMapping.homePhone);
+        const isOtherPhonePresent = isPhoneNumberPresent(participant, changedOption, conceptId, fieldMapping.otherPhone);
+        return !(isCellPhonePresent || isHomePhonePresent || isOtherPhonePresent);
+    }
+};
+
+/**
+ * get a user-friendly label for the modal
+ * @param {string} participantKey - the participant key (existing data structure) from the participant form 
+ * @returns - user-friendly label for the modal
+ */
+export const getModalLabel = (participantKey) => {
+    switch (participantKey) {
+        case 'LastName':
+            return 'Last Name';
+        case 'FirstName':
+            return 'First Name';
+        case 'MiddleName':
+            return 'Middle Name';
+        case 'PreferredName':
+            return 'Preferred Name';
+        case 'BirthMonth':
+            return 'Birth Month';
+        case 'BirthDay':
+            return 'Birth Day';
+        case 'BirthYear':
+            return 'Birth Year';
+        case 'Mobilephone':
+            return 'Mobile Phone';
+        case 'Text':
+            return 'Do we have permission to text this number';
+        case 'Mobilevoicemail':
+            return 'Do we have permission to leave a voicemail at this number';
+        case 'Homephone':
+            return 'Home Phone';
+        case 'Homevoicemail':
+            return 'Do we have permission to leave a voicemail at this number';
+        case 'Otherphone':
+            return 'Other Phone';
+        case 'Othervoicemail':
+            return 'Do we have permission to leave a voicemail at this number';
+        case 'Preferredemail':
+            return 'Preferred Email';
+        case 'Additionalemail1':
+            return 'Additional Email 1';
+        case 'Additionalemail2':
+            return 'Additional Email 2';
+        case 'Addressline1':
+            return 'Address Line 1';
+        case 'Addressline2':
+            return 'Address Line 2';
+        default:
+            return participantKey;
+    };
+};
+
+export const hideUneditableButtons = (participant, changedOption) => {
+    const importantRows = getImportantRows(participant, changedOption);
+    importantRows.forEach(row => {
+        if (!row.editable) {
+            const element = document.getElementById(`${row.field}button`);
+            if (element) {
+                element.style.display = 'none';
+            }
+        };
+    })
+};
+
+export const reloadParticipantData = async (token, siteKey) => {
+    showAnimation();
+    const query = `token=${token}`
+    const reloadedParticpant = await findParticipant(query);
+    mainContent.innerHTML = render(reloadedParticpant.data[0]);
+    renderParticipantDetails(reloadedParticpant.data[0], [],  {}, siteKey);
+    hideAnimation();
+}
+
+export const removeCamelCase = (participantKey) => {
+    let s = participantKey
+    s = s.replace(/([A-Z])/g, ' $1').trim()
+    return s;
+};
+
+export const renderReturnSearchResults = () => {
+    const a = document.getElementById('displaySearchResultsBtn');
+    if (a) {
+        a.addEventListener('click', () => {
+            renderLookupResultsTable();
+        })
+}};
+
+export const resetChanges = (participant, originalHTML, siteKey) => {
+    const a = document.getElementById("cancelChanges");
+    let template = '';
+    a.addEventListener("click", () => {
+        if ( appState.getState().unsavedChangesTrack.saveFlag === false ) {
+            mainContent.innerHTML = originalHTML;
+            renderParticipantDetails(participant, [], {}, siteKey);
+            appState.setState({unsavedChangesTrack:{saveFlag: false, counter: 0}})
+            let alertList = document.getElementById('alert_placeholder');
+            // throws an alert when canncel changes button is clicked
+            template += `<div class="alert alert-warning alert-dismissible fade show" role="alert">
+                            Changes cancelled.
+                            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                         </div>`
+            alertList.innerHTML = template;
+        }
+        else {  
+            alert('No changes to save or cancel');
+        }
+    })   
+}
+
+export const refreshParticipantAfterUpdate = async (participant, siteKey) => {
+    showAnimation();
+    localStorage.setItem('participant', JSON.stringify(participant));
+    renderParticipantDetails(participant, [], {}, siteKey);
+    appState.setState({unsavedChangesTrack:{saveFlag: false, counter: 0}})
+    let alertList = document.getElementById('alert_placeholder');
+    let template = '';
+    template += `<div class="alert alert-warning alert-dismissible fade show" role="alert">
+                    Success! Changes Saved.
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    </div>`
+    hideAnimation();
+    alertList.innerHTML = template;
+}
+
+/**
+ * Creates payload to be sent to backend and update the UI. Maps the field name back to concept id along with new responses.
+ * Updates the UI with the new responses.
+ * @param {object} participant - the participant being updated 
+ * @param {object} changedOption - object containing the participant's updated data points
+ * @param {HTMLElement} editedElement - the currently edited HTML element
+ * @param {object} adminSubjectAudit - record of the participant's data points before the update. This was existing and is not being referenced as of 05/18/2023. Retained for potential future use.)
+ */
+export const saveResponses = (participant, adminSubjectAudit, changedOption, editedElement) => {
+    let conceptIdArray = [];
+    const a = document.getElementById('formResponse')
+    a.addEventListener('submit', e => {
+        e.preventDefault()
+        const modifiedData = getDataAttributes(document.getElementById('fieldModified'));
+        conceptIdArray.push(modifiedData.fieldconceptid);
+
+        const newValueElement = document.getElementById('newValue');        
+        const dataValidationType = getImportantRows(participant, changedOption).find(row => row.field == modifiedData.fieldconceptid).validationType;
+        const isRequired = getIsRequiredField(participant, changedOption, newValueElement, conceptIdArray[conceptIdArray.length - 1]);
+        if (newValueElement.value != participant[conceptIdArray[conceptIdArray.length - 1]]) {
+            const newValueIsValid = validateNewValue(newValueElement, dataValidationType, isRequired);
+
+            if (newValueIsValid) {
+                changedOption[conceptIdArray[conceptIdArray.length - 1]] = newValueElement.value;
+                // if a changed field is a date of birth field then we need to update full date of birth  
+                if (fieldMapping.birthDay in changedOption || fieldMapping.birthMonth in changedOption || fieldMapping.birthYear in changedOption) {
+                    const day = fieldMapping.birthDay in changedOption
+                        ? changedOption[fieldMapping.birthDay]
+                        : participant[fieldMapping.birthDay]
+                    const month = fieldMapping.birthMonth in changedOption
+                        ? changedOption[fieldMapping.birthMonth]
+                        : participant[fieldMapping.birthMonth]
+                    const year = fieldMapping.birthYear in changedOption
+                        ? changedOption[fieldMapping.birthYear]
+                        : participant[fieldMapping.birthYear]
+                    const dateOfBirthComplete = fieldMapping.dateOfBirthComplete;
+                    conceptIdArray.push(dateOfBirthComplete);
+                    changedOption[conceptIdArray[conceptIdArray.length - 1]] =  year + month.padStart(2, '0')+ day.padStart(2, '0') ;
+                }
+
+                const displayAuditHistory = {};
+                const fieldChanged = getDataAttributes(document.getElementById('fieldModified'));
+                const currentValueData = getDataAttributes(document.getElementById('newValue'));
+                const timeStampData =  getCurrentTimeStamp();
+                const userIdData = getCurrentTimeStamp();
+                const source = "Site Manager Dashboard";
+                displayAuditHistory.token = participant.token;
+                displayAuditHistory.fieldModified = fieldChanged.fieldmodified;
+                displayAuditHistory.currentvalue = currentValueData.currentvalue;
+                displayAuditHistory.newValue = document.getElementById('newValue').value;
+                displayAuditHistory.timeStamp = timeStampData;
+                displayAuditHistory.userId = userIdData;
+                displayAuditHistory.source = source;
+                adminSubjectAudit.push(displayAuditHistory);
+
+                updateUIValues(editedElement, newValueElement.value, conceptIdArray);
+                closeModal();
+            };
+        } else {
+            showAlreadyExistsNoteInModal();
+        }    
+    });
+};
+
+/**
+ * update the UI after user edits a field
+ * @param {HTMLElement} editedElement - the element that was edited
+ * @param {string} newValue - the new value of the element
+ * @param {string[]} conceptIdArray - the concept id of the element, used for checking how to format the user's input
+ * update UI with a reminder to save changes, check for existing reminder so the message doesn't duplicate in a field
+ * toggle phone permission buttons if the user edits a phone number
+ */
+const updateUIValues = (editedElement, newValue, conceptIdArray) => {
+    const updatedEditValue = editedElement.querySelectorAll("td")[0];
+    updatedEditValue.textContent = getUITextForUpdatedValue(newValue, conceptIdArray);
+    const nextSiblingButton = updatedEditValue.nextElementSibling;
+    if (!nextSiblingButton.innerHTML.includes("Please save changes")) {
+        nextSiblingButton.innerHTML = `${nextSiblingButton.innerHTML}<br><br><i>Please save changes<br>before exiting the page</i>`;
+    }
+    updatedEditValue.parentNode.style.backgroundColor = "#FFFACA";
+
+    if (conceptIdArray.some(id => [fieldMapping.cellPhone, fieldMapping.homePhone, fieldMapping.otherPhone].includes(parseInt(id)))) {
+        togglePhonePermissionButtonsAndText(newValue, conceptIdArray);
+    }
+};
+
+/**
+ * Handle suffix text and phone permission text -> convert concept id to text
+ */
+const getUITextForUpdatedValue = (newValue, conceptIdArray) => {
+    if (conceptIdArray.includes(fieldMapping.suffix || fieldMapping.suffix.toString())) {
+        return suffixToTextMap.get(parseInt(newValue));
+    } else if (conceptIdArray.some(id => [fieldMapping.canWeText.toString(), fieldMapping.voicemailMobile.toString(), fieldMapping.voicemailHome.toString(), fieldMapping.voicemailOther.toString()].includes(id))) {
+        if (newValue == fieldMapping.yes) {
+            return 'Yes';
+        } else if (newValue == fieldMapping.no) {
+            return 'No';
+        } else {
+            return '';
+        }
+    } else {
+        return newValue;
+    }
+};
+
+const phoneTypeToPermissionsMapping = {
+    [fieldMapping.cellPhone]: [fieldMapping.voicemailMobile, fieldMapping.canWeText],
+    [fieldMapping.homePhone]: [fieldMapping.voicemailHome],
+    [fieldMapping.otherPhone]: [fieldMapping.voicemailOther]
+};
+
+/**
+ * Toggle the phone permission edit buttons based on whether the phone number exists
+ * if phone number exists, show the permission button(s) and prompt user to enter permissions
+ * permission buttons: voicemailMobile, canWeText (mobile only), voicemailHome, voicemailOther
+ * if phone number does not exist and this function triggers, this means user just deleted the phone number. Hide the relevant permission button(s)
+ * @param {string} newValue - the new value entered by the user 
+ * @param {Array<string>} conceptIdArray - the concept id of the element 
+ */
+const togglePhonePermissionButtonsAndText = (newValue, conceptIdArray) => {
+    const displayStatus = newValue.length === 10 ? 'block' : 'none';
+
+    for (const phoneType in phoneTypeToPermissionsMapping) {
+        if (conceptIdArray.includes(phoneType.toString())) {
+           phoneTypeToPermissionsMapping[phoneType].forEach(valueType => {
+                const button = document.getElementById(`${valueType}button`);
+                if (button) {
+                    button.style.display = displayStatus;
+                    if (displayStatus === 'block') {
+                        const noteField = document.getElementById(`${valueType}note`);
+                        if (noteField) {
+                            noteField.parentNode.parentNode.style.backgroundColor = "yellow";
+                            noteField.style.display = "block";
+                            noteField.innerHTML = `<i style="color:red;"><u>IMPORTANT:</u><br>*Please confirm member's contact permission*</i>`;
+                        }
+                    } else {
+                        const valueField = document.getElementById(`${valueType}value`);
+                        if (valueField) {
+                            valueField.textContent = '';
+                        }
+                    }
+                };
+           }); 
+           break;
+        }
+    }
+};
+
+export const showSaveNoteInModal = () => {
+    const a = document.getElementById('newValue');
+    if (a) {
+        a.addEventListener('click', () => {
+            const b = document.getElementById('showNote');
+            b.innerHTML = `After 'Submit' you must scroll down and click 'Save Changes' at bottom of screen for your changes to be saved.`
+        });
+    }
+};
+
+export const showAlreadyExistsNoteInModal = () => {
+    document.getElementById('showNote').innerHTML = `This value already exists. Please enter a different value or choose 'cancel'.<br>`;
+};
+
+export const suffixList = { 612166858: 0, 255907182: 1, 226924545: 2, 270793412: 3, 959021713: 4, 643664527: 5, 537892528: 6 };
+
+export const suffixToTextMap = new Map([
+    [612166858, 'Jr.'],
+    [255907182, 'Sr.'],
+    [226924545, 'I'],
+    [270793412, 'II'],
+    [959021713, 'III'],
+    [643664527, '2nd'],
+    [537892528, '3rd'],
+  ]);
+
+export const removeAllErrors = () => {
+    document.getElementById('showError').style.display = 'none';
+}
+
+export const errorMessage = (msg, editedElement) => {
+    const showError = document.getElementById('showError');
+    showError.innerHTML = `<p style="color: red; font-style: bold; font-size: 16px;">${msg}</p>`;
+    showError.style.display = 'block';
+    if(focus) editedElement.focus();
+}
+
+/**
+ * Route new value to the correct validation function based on the value type
+ * @param {HTMLElement} newValueElement - the element that was edited
+ * @param {string} newValueType - the type of value that was edited
+ * @param {boolean} isRequired - whether the value is required or optional
+ */
+const validateNewValue = (newValueElement, newValueType, isRequired) => {
+    let isValid = false;
+    switch (newValueType) {
+        case 'address':
+            isValid = validateAddress(newValueElement, isRequired);
+            break;
+        case 'day':
+            isValid = validateDay(newValueElement, isRequired);
+            break;
+        case 'email':
+            isValid = validateEmail(newValueElement, isRequired);
+            break;
+        case 'month':
+            isValid = validateMonth(newValueElement, isRequired);
+            break;
+        case 'phoneNumber':
+            isValid = validatePhoneNumber(newValueElement, isRequired);
+            break;
+        case 'text':
+            isValid = validateText(newValueElement, isRequired);
+            break;    
+        case 'year':
+            isValid = validateYear(newValueElement, isRequired);
+            break;
+        case 'zip':
+            isValid = validateZip(newValueElement, isRequired);
+            break;
+        case 'none':
+        case 'permissionSelector':  
+        case 'state':
+        case 'suffix':
+            isValid = true;
+            break;
+        default:
+            console.error('Error: Invalid value type in validateNewValue function.');
+            break;
+    }
+    return isValid;
+};
+
+export const validateAddress = (addressLineElement) => {
+    removeAllErrors();
+    if (!addressLineElement.value) {
+        errorMessage('Error: Please enter a value.', addressLineElement);
+        return false;
+    }
+    return true;
+};
+
+export const validateDay = (dayElement) => {
+    removeAllErrors();
+    const day = dayElement.value;
+    if (!day || day < 1 || day > 31) {
+        errorMessage('Error: Must be a valid day 01-31. Please try again.', dayElement);
+        return false;
+    }
+    return true;
+};
+
+export const validateEmail = (emailElement, isRequired) => {
+    removeAllErrors();
+    if (isRequired && !emailElement.value) {
+        errorMessage('Error: This field is required. Please enter a value.', emailElement);
+        return false;
+    }
+    
+    if (emailElement.value && !validEmailFormat.test(emailElement.value)) {
+        errorMessage('Error: The email address format is not valid. Please enter an email address in this format: name@example.com.', emailElement);
+        return false;
+    }
+    return true;
+};
+
+export const validateMonth = (monthElement) => {
+    removeAllErrors();
+    const month = monthElement.value;
+    if (!month || month < 1 || month > 12) {
+        errorMessage('Error: Must be a valid month 01-12. Please try again.', monthElement);
+        return false;
+    }
+    return true;
+};
+
+export const validateText = (textElement, isRequired) => {
+    removeAllErrors();
+
+    if (isRequired && !textElement.value) {
+        errorMessage('Error: This field is required. Please enter a value.', textElement);
+        return false;
+    }
+
+    if (textElement.value) {
+        if (!validNameFormat.test(textElement.value)) {
+            errorMessage('Error: Only Letters dashes, parenthesis, and some special characters are allowed. Please try again.', textElement);
+            return false;
+        }
+    }
+    return true;
+};
+
+export const validatePhoneNumber = (phoneNumberElement, isRequired) => {
+    removeAllErrors();
+    if (isRequired && !phoneNumberElement.value) {
+        errorMessage('At least one phone number is required. Please enter a 10-digit phone number. Example: 9999999999.', phoneNumberElement);
+        return false;
+    }
+
+    if (phoneNumberElement.value) {
+        if (!validPhoneNumberFormat.test(phoneNumberElement.value)) {
+            errorMessage('Please enter a 10-digit phone number with no punctuation. Example: 9999999999.', phoneNumberElement);
+            return false;
+        }
+    }
+    return true;
+}
+
+export const validateYear = (yearElement) => {
+    removeAllErrors();
+    const year = yearElement.value;
+    const currentYear = new Date().getFullYear();
+    if (!year || year < 1900 || year > currentYear) {
+        errorMessage(`Error: Must be a valid year 1900-${currentYear}. Please try again.`, yearElement);
+        return false;
+    }
+    return true;
+};
+
+export const validateZip = (zipElement) => {
+    removeAllErrors();
+    const zip = zipElement.value;
+    const zipRegExp = /[0-9]{5}/;
+    if (!zip || !zipRegExp.test(zip)) {
+        errorMessage('Error: Must be 5 digits. Please try again.', zipElement);
+        return false;
+    }
+    return true;
+};
+
+// These match validations RegExps in connectApp -> shared.js
+const validEmailFormat = /^[a-zA-Z0-9.!#$%&'*+"\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,63}$/;
+const validNameFormat = /^[A-Za-zÀ-ÖØ-öø-ÿ\s'\-.]+$/i;
+const validPhoneNumberFormat =
+  /^[\+]?(?:1|1-|1\.|1\s+)?[(]?[0-9]{3}[)]?(?:-|\s+|\.)?[0-9]{3}(?:-|\s+|\.)?[0-9]{4}$/;
+
+
+// Admin audit displaying logs
+export const viewAuditHandler = (adminSubjectAudit) => {
+    const a = document.getElementById('adminAudit');
+    if (a) {
+        a.addEventListener('click',  () => {
+            buttonAuditHandler(adminSubjectAudit);
+        })
+    }
+}
+
+export const viewParticipantSummary = (participant) => {
+    const a = document.getElementById('viewSummary');
+    if (a) {
+        a.addEventListener('click',  () => {  
+            renderParticipantSummary(participant);
+        })
+    }
+}
+
+/**
+ * Process the user's update and submit the new user data to the database.
+ * if participant is verified, fetch logged in admin's email (the person processing the edit) to attach to the user's history update
+ * If successful, update the participant object in local storage.
+ * Else, alert the user that the update was unsuccessful.
+ * @param {object} participant - the existing participant object 
+ * @param {object} changedOption - the changed user data
+ * @param {string} siteKey - the site key to pass to the POST request 
+ */
+export const submitClickHandler = async (participant, changedOption, siteKey) => {
+    const isParticipantVerified = participant[fieldMapping.verifiedFlag] == fieldMapping.verified;
+    let adminEmail = '';
+    if (isParticipantVerified) {
+        adminEmail = await fetchUpdatingAdminEmailAddress();
+    }
+    const submitButtons = document.getElementsByClassName('updateMemberData');
+    for (const button of submitButtons) {
+        button.addEventListener('click', async (e) => {
+            if (Object.keys(changedOption).length === 0) {
+                alert('No changes to submit. No changes have been made. Please update the form and try again if changes are needed.');
+            } else {
+                const { changedUserDataForProfile, changedUserDataForHistory } = findChangedUserDataValues(changedOption, participant);
+                const isSuccess = processUserDataUpdate(changedUserDataForProfile, changedUserDataForHistory, participant[fieldMapping.userProfileHistory], participant.state.uid, adminEmail, isParticipantVerified);
+                if (isSuccess) {
+                    const updatedParticipant = { ...participant, ...changedUserDataForProfile};
+                    await refreshParticipantAfterUpdate(updatedParticipant, siteKey);
+                } else {
+                    alert('Error: There was an error processing your changes. Please try again.');
+                }
+            }
+        });
+    }
+};
+
+  /**
+ * Iterate the new values, compare them to existing values, and return the changed values.
+ * write an empty string to firestore if the history value is null/undefined/empty --per spec on 05-09-2023
+ * write an empty string ti firestore if the profile value is null/undefined/empty --per spec on 05-09-2023
+ * @param {object} newUserData - the newly entered form fields
+ * @param {object} existingUserData - the existing user profile data
+ * @returns {changedUserDataForProfile, changedUserDataForHistory} - parallel objects containing the changed values
+ * Contact information requires special handling because of the preference selectors
+ *   if the user is changing their cell phone number, we need to update the canWeVoicemailMobile and canWeText values
+ *   the same is true for homePhone and otherPhone (canWeVoicemailHome and canWeVoicemailOther)
+ *   if user deletes a number, set canWeVoicemail and canWeText to '' (empty string) --per spec on 05-09-2023
+ *   if user updates a number, ensure the canWeVoicemail and canWeText values are set. Use previous values as fallback.
+*/
+const findChangedUserDataValues = (newUserData, existingUserData) => {
+    const changedUserDataForProfile = {};
+    const changedUserDataForHistory = {};
+    Object.keys(newUserData).forEach(key => {
+      if (newUserData[key] !== existingUserData[key]) {
+        changedUserDataForProfile[key] = newUserData[key] ?? '';
+        changedUserDataForHistory[key] = existingUserData[key] ?? '';
+      }
+    });
+  
+    if (fieldMapping.cellPhone in changedUserDataForProfile) {
+        if (!newUserData[fieldMapping.cellPhone]) {
+            changedUserDataForProfile[fieldMapping.voicemailMobile] = '';
+            changedUserDataForProfile[fieldMapping.canWeText] = '';
+        } else {
+            changedUserDataForProfile[fieldMapping.voicemailMobile] = newUserData[fieldMapping.voicemailMobile] ?? existingUserData[fieldMapping.voicemailMobile] ?? fieldMapping.no;
+            changedUserDataForProfile[fieldMapping.canWeText] = newUserData[fieldMapping.canWeText] ?? existingUserData[fieldMapping.canWeText] ?? fieldMapping.no;
+        }
+        changedUserDataForHistory[fieldMapping.voicemailMobile] = existingUserData[fieldMapping.voicemailMobile] ?? fieldMapping.no;
+        changedUserDataForHistory[fieldMapping.canWeText] = existingUserData[fieldMapping.canWeText] ?? fieldMapping.no;
+    }
+
+    if (fieldMapping.homePhone in changedUserDataForProfile) {
+        if (!newUserData[fieldMapping.homePhone]) {
+            changedUserDataForProfile[fieldMapping.voicemailHome] = '';
+        } else {
+            changedUserDataForProfile[fieldMapping.voicemailHome] = newUserData[fieldMapping.voicemailHome] ?? existingUserData[fieldMapping.voicemailHome] ?? fieldMapping.no;
+        }
+        changedUserDataForHistory[fieldMapping.voicemailHome] = existingUserData[fieldMapping.voicemailHome] ?? fieldMapping.no;
+    }
+
+    if (fieldMapping.otherPhone in changedUserDataForProfile) {
+        if (!newUserData[fieldMapping.otherPhone]) {
+            changedUserDataForProfile[fieldMapping.voicemailOther] = '';
+        } else {
+            changedUserDataForProfile[fieldMapping.voicemailOther] = newUserData[fieldMapping.voicemailOther] ?? existingUserData[fieldMapping.voicemailOther] ?? fieldMapping.no;
+        }
+        changedUserDataForHistory[fieldMapping.voicemailOther] = existingUserData[fieldMapping.voicemailOther] ?? fieldMapping.no;
+    }
+
+return { changedUserDataForProfile, changedUserDataForHistory };
+};
+  
+/**
+ * Check whether changes were made to the user profile. If so, update the user profile and history.
+ * Only write the history portion if the user is verified. Do not write history if the user is not verified.
+ * Specifically, don't write history if the submittedFlag is true but participant[fieldMapping.verifiedFlag] !== fieldMapping.verified.
+ * @param {object} changedUserDataForProfile - the changed values to be written to the user profile
+ * @param {object} changedUserDataForHistory  - the previous values to be written to history.
+ * @param {object} userHistory - the user's existing history
+ * @param {string} type - the type of data being changed (e.g. name, contact info, mailing address, log-in email)
+ * @returns {boolean} - whether the write operation was successful to control the UI messaging
+ */
+const processUserDataUpdate = async (changedUserDataForProfile, changedUserDataForHistory, userHistory, participantUID, adminEmail, isParticipantVerified) => {
+        if (isParticipantVerified) {
+            changedUserDataForProfile[fieldMapping.userProfileHistory] = updateUserHistory(changedUserDataForHistory, userHistory, adminEmail);
+        }
+        changedUserDataForProfile['uid'] = participantUID;
+        await postUserDataUpdate(changedUserDataForProfile)
+        .catch(function (error) {
+            console.error('Error writing document (postUserDataUpdate) ', error);
+            return false;
+        });
+        return true;
+};
+  
+/**
+ * Update the user's history based on new data entered by the user. This only triggers if the user's profile is verified.
+ * Prepare it for POST to user's proifle in firestore
+ * This routine runs once per form submission.
+ * First, check for user history and add it to the userProfileHistoryArray.
+ * Next, create a new map of the user's changes and add it to the userProfileHistoryArray with a timestamp
+ * @param {array of objects} existingDataToUpdate - the existingData to write to history (parallel data structure to newDataToWrite)
+ * @param {array of objects} userHistory - the user's existing history
+ * @returns {userProfileHistoryArray} -the array of objects to write to user profile history, with the new data added to the end of the array
+ */
+const updateUserHistory = (existingDataToUpdate, userHistory, adminEmail) => {
+    const userProfileHistoryArray = [];
+    if (userHistory && Object.keys(userHistory).length > 0) userProfileHistoryArray.push(...userHistory);
+
+    const newUserHistoryMap = populateUserHistoryMap(existingDataToUpdate, adminEmail);
+    userProfileHistoryArray.push(newUserHistoryMap);
+
+    return userProfileHistoryArray;
+};
+
+const populateUserHistoryMap = (existingData, adminEmail) => {
+    const userHistoryMap = {};
+    const keys = [
+        fieldMapping.fName,
+        fieldMapping.mName,
+        fieldMapping.lName,
+        fieldMapping.suffix,
+        fieldMapping.prefName,
+        fieldMapping.birthDay,
+        fieldMapping.birthMonth,
+        fieldMapping.birthYear,
+        fieldMapping.dateOfBirthComplete,
+        fieldMapping.cellPhone,
+        fieldMapping.voicemailMobile,
+        fieldMapping.canWeText,
+        fieldMapping.homePhone,
+        fieldMapping.voicemailHome,
+        fieldMapping.otherPhone,
+        fieldMapping.voicemailOther,
+        fieldMapping.email,
+        fieldMapping.email1,
+        fieldMapping.email2,
+        fieldMapping.address1,
+        fieldMapping.address2,
+        fieldMapping.city,
+        fieldMapping.state,
+        fieldMapping.zip,
+        fieldMapping.firebaseAuthEmail,
+    ];
+
+    keys.forEach((key) => {
+        existingData[key] != null && (userHistoryMap[key] = existingData[key]);
+    });
+
+    if (existingData[fieldMapping.cellPhone] != null) {
+        userHistoryMap[fieldMapping.voicemailMobile] = existingData[fieldMapping.voicemailMobile];
+        userHistoryMap[fieldMapping.canWeText] = existingData[fieldMapping.canWeText];
+    }
+
+    if (existingData[fieldMapping.homePhone] != null) {
+        userHistoryMap[fieldMapping.voicemailHome] = existingData[fieldMapping.voicemailHome];
+    }
+
+    if (existingData[fieldMapping.otherPhone] != null) {
+        userHistoryMap[fieldMapping.voicemailOther] = existingData[fieldMapping.voicemailOther];
+    }
+
+    if (Object.keys(userHistoryMap).length > 0) {
+        userHistoryMap[fieldMapping.userProfileUpdateTimestamp] = new Date().toISOString();
+        userHistoryMap[fieldMapping.profileChangeRequestedBy] = adminEmail;
+    }
+
+    return userHistoryMap;
+};
+
+export const fetchUpdatingAdminEmailAddress = async () => {
+    try {
+      const email = await getLoggedInUserForHistory();
+      return email;
+    } catch (error) {
+      console.error('Failed to fetch updating admim user\'s email:', error);
+      return '';
+    }
+}
+
+export const postUserDataUpdate = async (changedUserData) => {
+    try {
+        const idToken = await getIdToken();
+        const response = await fetch(`${baseAPI}/dashboard?api=updateParticipantDataNotSite`, {
+            method: "POST",
+            headers:{
+                Authorization: "Bearer " + idToken,
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(changedUserData)
+        });
+
+        if (!response.ok) { 
+            const error = (response.status + ": " + (await response.json()).message) || response.status;
+            throw new Error(error);
+        }
+        
+        return await response.json();
+    } catch (error) {
+        console.error('Error in postUserDataUpdate:', error);
+        throw error;
+    }
+}

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -313,8 +313,9 @@ export const getImportantRows = (participant, changedOption) => {
     console.log(appState.getState().loginMechanism.phone);
     console.log(appState.getState().userSession?.email);
     console.log('userLoginEmail', userLoginEmail);
-    const permDomains = /(nih.gov|norc.org)$/i;
-    permDomains.test(userLoginEmail.split('@')[1]) && importantRowsArray.push(...loginChangeInfoArray);
+    //const permDomains = /(nih.gov|norc.org)$/i;
+    //permDomains.test(userLoginEmail.split('@')[1]) &&
+    importantRowsArray.push(...loginChangeInfoArray);
 
     return importantRowsArray; 
 };

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -3,7 +3,7 @@ import { render, renderParticipantDetails } from './participantDetails.js';
 import { findParticipant, renderLookupResultsTable } from './participantLookup.js';
 import { renderParticipantSummary } from './participantSummary.js';
 import { appState } from './stateManager.js';
-import { baseAPI, getCurrentTimeStamp, getDataAttributes, getIdToken, hideAnimation, showAnimation } from './utils.js';
+import { baseAPI, getDataAttributes, getIdToken, hideAnimation, showAnimation } from './utils.js';
 
 export const allStates = {
     "Alabama":1,
@@ -60,43 +60,40 @@ export const allStates = {
     "NA": 52
 }
 
-const buttonAuditHandler = (adminSubjectAudit) => {
-    const header = document.getElementById('modalHeader');
-    const body = document.getElementById('modalBody');
-    header.innerHTML = `<h5>Audit History</h5><button type="button" class="modal-close-btn" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
-    let template = '<div>'
-    adminSubjectAudit.length === 0 ? (
-        template+= `<span> No changes to show </span></div>`
-    ) : (
-    adminSubjectAudit.map(element => {
-        template += `<span>
-            ${element.outerHTML};
-        </span>
-    </div>`
-    }))
-    
-    body.innerHTML = template;
-}
-
 export const closeModal = () => {
     const modalClose = document.getElementById('modalShowMoreData');
     modalClose.querySelector('#closeModal').click();
 };
 
-export const fieldValues = 
-    {       
-        353358909: 'Yes',
-        104430631: 'No',
-        612166858: 'Jr.',
-        255907182: 'Sr.',
-        226924545: 'I',
-        270793412: 'II',
-        959021713: 'III',
-        643664527: '2nd',
-        537892528: '3rd',
-        127547625: 'Phone',
-        869588347: 'Email'
+const fieldValues = {     
+    [fieldMapping.yes]: 'Yes',
+    [fieldMapping.no]: 'No',
+    [fieldMapping.jr]: 'Jr.',
+    [fieldMapping.sr]: 'Sr.',
+    [fieldMapping.one]: 'I',
+    [fieldMapping.two]: 'II',
+    [fieldMapping.three]: 'III',
+    [fieldMapping.second]: '2nd',
+    [fieldMapping.third]: '3rd',
+    [fieldMapping.prefPhone]: 'Phone',
+    [fieldMapping.email]: 'Email',
+}
+
+export const getFieldValues = (variableValue, cId) => {
+    const phoneFieldValues = {
+        [fieldMapping.cellPhone]: formatPhoneNumber(variableValue.toString()),
+        [fieldMapping.homePhone]: formatPhoneNumber(variableValue.toString()),
+        [fieldMapping.otherPhone]: formatPhoneNumber(variableValue.toString())
     }
+
+    if (variableValue in fieldValues){
+        return fieldValues[variableValue];
+    } else if (cId in phoneFieldValues){
+        return phoneFieldValues[cId];
+    } else {
+        return variableValue;
+    }
+}
 
 export const formatInputResponse = (participantValue) => {
     let ptValue = '';
@@ -470,9 +467,8 @@ export const refreshParticipantAfterUpdate = async (participant, siteKey) => {
  * @param {object} participant - the participant being updated 
  * @param {object} changedOption - object containing the participant's updated data points
  * @param {HTMLElement} editedElement - the currently edited HTML element
- * @param {object} adminSubjectAudit - record of the participant's data points before the update. This was existing and is not being referenced as of 05/18/2023. Retained for potential future use.)
  */
-export const saveResponses = (participant, adminSubjectAudit, changedOption, editedElement, cId) => {
+export const saveResponses = (participant, changedOption, editedElement, cId) => {
     let conceptIdArray = [];
     const a = document.getElementById('formResponse')
     a.addEventListener('submit', e => {
@@ -497,21 +493,6 @@ export const saveResponses = (participant, adminSubjectAudit, changedOption, edi
                     conceptIdArray.push(dateOfBirthComplete);
                     changedOption[conceptIdArray[conceptIdArray.length - 1]] =  year + month.padStart(2, '0')+ day.padStart(2, '0') ;
                 }
-
-                const displayAuditHistory = {};
-                const fieldChanged = modifiedData;
-                const currentValueData = getDataAttributes(newValueElement);
-                const timeStampData =  getCurrentTimeStamp();
-                const userIdData = getCurrentTimeStamp();
-                const source = "Site Manager Dashboard";
-                displayAuditHistory.token = participant.token;
-                displayAuditHistory.fieldModified = fieldChanged.fieldmodified;
-                displayAuditHistory.currentvalue = currentValueData.currentvalue;
-                displayAuditHistory.newValue = document.getElementById(`newValue${cId}`).value;
-                displayAuditHistory.timeStamp = timeStampData;
-                displayAuditHistory.userId = userIdData;
-                displayAuditHistory.source = source;
-                adminSubjectAudit.push(displayAuditHistory);
 
                 updateUIValues(editedElement, newValueElement.value, conceptIdArray);
                 closeModal();
@@ -794,17 +775,6 @@ export const validEmailFormat = /^[a-zA-Z0-9.!#$%&'*+"\/=?^_`{|}~-]+@[a-zA-Z0-9]
 export const validNameFormat = /^[A-Za-zÀ-ÖØ-öø-ÿ\s'\-.]+$/i;
 export const validPhoneNumberFormat =
   /^[\+]?(?:1|1-|1\.|1\s+)?[(]?[0-9]{3}[)]?(?:-|\s+|\.)?[0-9]{3}(?:-|\s+|\.)?[0-9]{4}$/;
-
-
-// Admin audit displaying logs
-export const viewAuditHandler = (adminSubjectAudit) => {
-    const a = document.getElementById('adminAudit');
-    if (a) {
-        a.addEventListener('click',  () => {
-            buttonAuditHandler(adminSubjectAudit);
-        })
-    }
-}
 
 export const viewParticipantSummary = (participant) => {
     const a = document.getElementById('viewSummary');

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -285,15 +285,15 @@ export const getImportantRows = (participant, changedOption) => {
             validationType: 'none',
             isRequired: true
         },
+    ];
+
+    const loginChangeInfoArray = [
         { field: `Change Login Mode`,
             label: 'Change Login Mode',
             editable: true,
             display: true,
             validationType: 'none'
         },
-    ];
-
-    const loginChangeInfoArray = [
         { field: `Change Login Email`,
             label: 'Change Login Email',
             editable: true,
@@ -309,12 +309,8 @@ export const getImportantRows = (participant, changedOption) => {
     ];
 
     const userLoginEmail = appState.getState().userSession?.email ?? '';
-    console.log(appState.getState().loginMechanism.email);
-    console.log(appState.getState().loginMechanism.phone);
-    console.log(appState.getState().userSession?.email);
-    console.log('userLoginEmail', userLoginEmail);
-    //const permDomains = /(nih.gov|norc.org)$/i;
-    //permDomains.test(userLoginEmail.split('@')[1]) &&
+    const permDomains = /(nih.gov|norc.org)$/i;
+    permDomains.test(userLoginEmail.split('@')[1]) &&
     importantRowsArray.push(...loginChangeInfoArray);
 
     return importantRowsArray; 

--- a/siteManagerDashboard/utils.js
+++ b/siteManagerDashboard/utils.js
@@ -97,6 +97,24 @@ export const getIdToken = () => {
   });
 };
 
+export const getLoggedInUserForHistory = () => {
+  return new Promise((resolve, reject) => {
+    const unsubscribe = firebase.auth().onAuthStateChanged((user) => {
+        unsubscribe();
+        if (user) {
+          resolve(user.email)
+        } else {
+          resolve(null);
+        }
+    });
+    // Handle timeout error after 10 seconds
+    setTimeout(() => {
+      unsubscribe();
+      reject(new Error('Timeout error.'));
+    }, 10000);
+  });
+};
+
 // shows/hides a spinner when HTTP request is made/screen is loading
 export const showAnimation = () => {
   if(document.getElementById('loadingAnimation')) document.getElementById('loadingAnimation').style.display = '';

--- a/siteManagerDashboard/utils.js
+++ b/siteManagerDashboard/utils.js
@@ -97,24 +97,6 @@ export const getIdToken = () => {
   });
 };
 
-export const getLoggedInUserForHistory = () => {
-  return new Promise((resolve, reject) => {
-    const unsubscribe = firebase.auth().onAuthStateChanged((user) => {
-        unsubscribe();
-        if (user) {
-          resolve(user.email)
-        } else {
-          resolve(null);
-        }
-    });
-    // Handle timeout error after 10 seconds
-    setTimeout(() => {
-      unsubscribe();
-      reject(new Error('Timeout error.'));
-    }, 10000);
-  });
-};
-
 // shows/hides a spinner when HTTP request is made/screen is loading
 export const showAnimation = () => {
   if(document.getElementById('loadingAnimation')) document.getElementById('loadingAnimation').style.display = '';


### PR DESCRIPTION
This PR addresses [issue #635](https://github.com/episphere/connect/issues/635) - User Profile Archiving - in SMDB.

• Refactored participantDetails.js for readability & maintainability (removed most embedded logic and modularized code).

• Added user profile editing functionality (Firestore write to user profile).

• Added user profile archiving (Firestore write to user profile).
Only archive profile for verified participants.
Added ‘who requested change’ conceptId 611005658. This is a new requirement.

• Editable item toggling: once verified, date of birth items (day, month, year) are no longer editable.

• Implemented dropdown selectors for all selectable fields (day, month, state, suffix).

• Implemented validation on all non-selectable items.

• Differentiated between required and optional fields for validation & nullabiility.

• Hide edit buttons for uneditable fields.

• Implemented reminders to re-verify user voicemail & text permissions when a phone number is added.

• Merged with Warren’s recent high-priority update to login methods. Tested compatibility & functionality - we were both working in `participantDetails.js` at the same time.
