### PR TITLE
bug fix - write dataDestroyCategorical in SMDB

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -379,6 +379,8 @@ export default
     "revokeHIPAAOnly": 872012139,
     "withdrewConsent": 854021266,
     "destroyDataStatus": 241236037,
+    "dataDestroyCategorical": 883668444,
+    "requestedDataDestroyNotSigned": 111959410,
     "deceased": 618686157,
 
     'dateWithdrewConsentRequested': 659990606,

--- a/siteManagerDashboard/participantWithdrawalForm.js
+++ b/siteManagerDashboard/participantWithdrawalForm.js
@@ -350,7 +350,7 @@ const optionsHandler = (suspendDate) => {
 export const proceedToNextPage = (retainOptions, requestedHolder, suspendDate) => {
     const a = document.getElementById('proceedFormPage');
     if (a) {
-        a.addEventListener('click',  () => { 
+        a.addEventListener('click',  () => {
             let checkedValue = document.getElementById('messageCheckbox').checked;
             checkedValue ? causeOfDeathPage(retainOptions) : reasonForRefusalPage(retainOptions, requestedHolder, suspendDate);
         })
@@ -527,6 +527,7 @@ const sendResponses = async (finalOptions, retainOptions, requestedHolder, sourc
     }
     if (computeScore === fieldMapping.destroyDataStatus) { 
         sendRefusalData[fieldMapping.dateDataDestroyRequested] = new Date().toISOString();
+        sendRefusalData[fieldMapping.dataDestroyCategorical] = fieldMapping.requestedDataDestroyNotSigned;
         updateWhoRequested(sendRefusalData, fieldMapping.whoRequestedDataDestruction, fieldMapping.whoRequestedDataDestructionOther)
     }
     if (computeScore === fieldMapping.revokeHIPAAOnly) { 


### PR DESCRIPTION
This PR updates SMDB to set `8836684441` to `111959410` when a user requests data destruction in SMDB.

SMDB User withdrawal:

The conceptId `831041022` ‘Destroy Data : Wants data destroyed’
is a yes/no variable. It is getting set to `355358909`  ‘yes’ when a user submits the withdrawal form in SMDB.

The conceptId dictionary also contains the following variables for data destruction:
`883668444` = Destroy data categorical, associated with these options:
`457944265` = ‘Current Question Text: Not requested’
`111959410` = ‘Current Question Text:  Requested but not signed’
`704529432` = ‘Current Question Text:  Requested and signed’

The status: 'requested but not signed' is needed for our automated data destroy tasks. At this point in the flow, data destruction has been requested, but the participant still needs to sign the form in connectApp. This PR updates SMDB to set
`8836684441` to `111959410` when a user requests data destruction in SMDB.
