### PR TITLE
Smdb multiple authentication methods

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -381,6 +381,7 @@ export default
     "destroyDataStatus": 241236037,
     "dataDestroyCategorical": 883668444,
     "requestedDataDestroyNotSigned": 111959410,
+    "requestedDataDestroySigned": 704529432,
     "deceased": 618686157,
 
     'dateWithdrewConsentRequested': 659990606,

--- a/siteManagerDashboard/index.js
+++ b/siteManagerDashboard/index.js
@@ -87,8 +87,7 @@ const router = async () => {
             } else {
                 let participant = JSON.parse(localStorage.getItem("participant"));
                 let changedOption = {};
-                const bearerToken = await getAccessToken();
-                renderParticipantDetails(participant, changedOption, bearerToken);
+                renderParticipantDetails(participant, changedOption);
             }
         }
         else if (route === '#participantSummary') {

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -24,20 +24,19 @@ window.addEventListener('onload', (e) => {
 const checkForLoginMechanism = (participant) => {
     const isPhoneLogin = getIsPhone(participant && participant[fieldMapping.signInMechansim]);
     const isEmailLogin = getIsEmail(participant && participant[fieldMapping.signInMechansim]);
-    //TODO: This handles multiple auth methods: Remove now (recommended by Abhinav), add back in when multiple logins are working: this is the next project in line.
-    // if (isPhoneLogin && isEmailLogin) {
-    //     appState.setState({loginMechanism:{phone: true, email: true}})
-    //     participant['Change Login Mode'] = 'Email 📧 and Phone ☎️'
-    //     participant['Change Login Phone'] = participant[fieldMapping.accountPhone]
-    //     participant['Change Login Email'] = participant[fieldMapping.accountEmail]
-    // } else 
+    if (isPhoneLogin && isEmailLogin) {
+        appState.setState({loginMechanism:{phone: true, email: true}})
+        //participant['Change Login Mode'] = 'Email 📧 and Phone ☎️'
+        participant['Change Login Phone'] = participant[fieldMapping.accountPhone]
+        participant['Change Login Email'] = participant[fieldMapping.accountEmail]
+    } else 
     if (isPhoneLogin) {
         appState.setState({loginMechanism:{phone: true, email: false}})
-        participant['Change Login Mode'] = 'Phone ☎️'
+        //participant['Change Login Mode'] = 'Phone ☎️'
         participant['Change Login Phone'] = participant[fieldMapping.accountPhone]
     } else { 
         appState.setState({loginMechanism:{phone: false, email: true}}) 
-        participant['Change Login Mode'] = 'Email 📧'
+        //participant['Change Login Mode'] = 'Email 📧'
         participant['Change Login Email'] = participant[fieldMapping.accountEmail]
     }
 }
@@ -57,7 +56,7 @@ export const renderParticipantDetails = (participant, changedOption, bearerToken
     viewParticipantSummary(participant);
     renderReturnSearchResults();
     updateUserSigninMechanism(participant, bearerToken);
-    updateUserLogin(participant, bearerToken);
+    //updateUserLogin(participant, siteKey);
     submitClickHandler(participant, changedOption, bearerToken);
 }
 
@@ -167,13 +166,14 @@ const getButtonToRender = (participantSignInMechanism, variableLabel, conceptId,
             <button type="button" class="btn btn-primary btn-custom">Edit</button>
         </a>
         `;
-    const changeLoginModeButton = `<button type="button" class="btn btn-primary btn-custom" data-toggle="modal" data-target="#modalShowMoreData" id="switchSiginMechanism">Change</button>`;
-    const updateLoginEmailButton = `<button type="button" class="btn btn-primary btn-custom" data-toggle="modal" data-target="#modalShowMoreData" data-participantLoginUpdate='email' id="updateUserLogin">Update</button>`;
-    const updateLoginPhoneButton = `<button type="button" class="btn btn-primary btn-custom" data-toggle="modal" data-target="#modalShowMoreData" data-participantLoginUpdate='phone' id="updateUserLogin">Update</button>`;
+    //const changeLoginModeButton = `<button type="button" class="btn btn-primary btn-custom" data-toggle="modal" data-target="#modalShowMoreData" id="switchSiginMechanism">Change</button>`;
+    const updateLoginEmailButton = `<button type="button" class="btn btn-primary btn-custom" data-toggle="modal" data-target="#modalShowMoreData" data-participantLoginUpdate='email' id="updateUserLogin">Edit</button>`;
+    const updateLoginPhoneButton = `<button type="button" class="btn btn-primary btn-custom" data-toggle="modal" data-target="#modalShowMoreData" data-participantLoginUpdate='phone' id="updateUserLogin">Edit</button>`;
 
-    if (conceptId === 'Change Login Mode') {
-        return changeLoginModeButton;
-    } else if (conceptId === 'Change Login Email' && getIsEmail(participantSignInMechanism)) {
+    // if (conceptId === 'Change Login Mode') {
+    //     return changeLoginModeButton;
+    // } else 
+    if (conceptId === 'Change Login Email' && getIsEmail(participantSignInMechanism)) {
         return updateLoginEmailButton;
     } else if (conceptId === 'Change Login Phone' && getIsPhone(participantSignInMechanism)) {
         return updateLoginPhoneButton;
@@ -290,141 +290,51 @@ const saveAltResponse = (participant) => {
     })
 }
 
-// async-await function to make HTTP POST request
-async function signInMechanismClickHandler(updatedOptions, bearerToken)  {
-    try {
-        showAnimation();
+const generateInputFields = (isPhone, participant) => {
+    const currentLogin = isPhone ? participant[fieldMapping.accountPhone] : participant[fieldMapping.accountEmail];
+    const labelForNewLogin = isPhone ? 'Enter New Email Login' : 'Enter New Phone Login';
+    const placeholderForNewLogin = isPhone ? 'Enter Email' : 'Enter phone number without dashes & parenthesis';
+    const newLoginId = isPhone ? 'newEmail' : 'newPhone';
+    const confirmLabel = isPhone ? 'Confirm New Email Login' : 'Confirm New Phone Login';
+    const confirmId = isPhone ? 'confirmEmail' : 'confirmPhone';
 
-        const updateParticpantPayload = {
-            "data": [updatedOptions]
-        }
+    return `<div class="form-group">
+                <label class="col-form-label search-label">Current Login</label>
+                <input class="form-control" value=${currentLogin} disabled/>
+                <label class="col-form-label search-label">${labelForNewLogin}</label>
+                <input class="form-control" id="${newLoginId}" placeholder="${placeholderForNewLogin}"/>
+                <label class="col-form-label search-label">${confirmLabel}</label>
+                <input class="form-control" id="${confirmId}" placeholder="Confirm"/>
+            </div>`;
+};
 
-        const response = await fetch(`${baseAPI}/dashboard?api=updateParticipantData`,{
-            method:'POST',
-            body: JSON.stringify(updateParticpantPayload),
-            headers:{
-                Authorization:"Bearer " + bearerToken,
-                "Content-Type": "application/json"
-                }
-        });
-        hideAnimation();
+const generateFormButtons = () => {
+    return `<div class="form-group">
+                <button type="submit" class="btn btn-danger" data-dismiss="modal" target="_blank">Cancel</button>
+                <button type="submit" class="btn btn-primary" data-toggle="modal">Submit</button>
+            </div>`;
+};
 
-        if (response.status === 200) {
-            document.getElementById('loadingAnimation').style.display = 'none';
-            appState.setState({unsavedChangesTrack:{saveFlag: true, counter: 0}})
-            const alertList = document.getElementById("alert_placeholder");
-            let template = ``;
-            template += `
-                    <div class="alert alert-success alert-dismissible fade show" role="alert">
-                    Participant detail updated!
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                    </div>`;
-            alertList.innerHTML = template;
-            return true;
-        } else { 
-            throw new Error('Error: (signInMechanismClickHandler())');
-        }
-    } catch (error) {
-        console.error('Error in updating participant data (signInMechanismClickHandler())', error);
-        hideAnimation();
-        alert('Error in updating participant data. Please try again.');
-        return false;
-    }
-}
-
-const updateUserSigninMechanism = (participant, bearerToken) => {
-    const switchSiginButton = document.getElementById('switchSiginMechanism');
+const updateUserSigninMechanism = (participant, siteKey) => {
+    const switchSigninButton = document.getElementById('updateUserLogin');
     const isPhone = getIsPhone(participant[fieldMapping.signInMechansim]);
     const isEmail = getIsEmail(participant[fieldMapping.signInMechansim]); 
-    let template = ``
-    if (switchSiginButton) {
-        switchSiginButton.addEventListener('click', () => {
+
+    if (switchSigninButton) {
+        switchSigninButton.addEventListener('click', () => {
             const header = document.getElementById('modalHeader');
             const body = document.getElementById('modalBody');
-            header.innerHTML = `<h5>Change Login Mode</h5><button type="button" class="modal-close-btn" data-dismiss="modal" id="closeModal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
-            template = `<div> <form id="formResponse2" method="post"> `
-            if (isPhone) {
-                template +=  `<div class="form-group">
-                            <label class="col-form-label search-label">Current Login</label>
-                            <input class="form-control" value=${participant[fieldMapping.accountPhone]} disabled/>
-                            <label class="col-form-label search-label">Enter New Email Login</label>
-                            <input class="form-control" type="email" id="newEmail" placeholder="Enter Email"/>
-                            <label class="col-form-label search-label">Confirm New Email Login</label>
-                            <input class="form-control" type="email" id="confirmEmail" placeholder="Confim Email"/>
-                        </div>`
-            }
-            else if (isEmail) {
-                template +=  `<div class="form-group">
-                            <label class="col-form-label search-label">Current Login</label>
-                            <input class="form-control" value=${participant[fieldMapping.accountEmail]} disabled/>
-                            <label class="col-form-label search-label">Enter New Phone Login</label>
-                            <input class="form-control" id="newPhone" placeholder="Enter phone number without dashes & parenthesis"/>
-                            <label class="col-form-label search-label">Confirm New Phone Login</label>
-                            <input class="form-control" id="confirmPhone" placeholder="Confim phone number"/>
-                        </div>`
-            }
-            template += `<div class="form-group">
-                            <button type="submit" class="btn btn-danger" data-dismiss="modal" target="_blank">Cancel</button>
-                            <button type="submit" class="btn btn-primary" data-toggle="modal">Submit</button>
-                        </div>
-                    </form>
-                </div>`
-            body.innerHTML = template;
-            let prevCounter =  appState.getState().unsavedChangesTrack.counter
-            appState.setState({unsavedChangesTrack:{saveFlag: false, counter: prevCounter+1}});
-            processSwitchSigninMechanism(participant, bearerToken, 'replaceSignin');
-        })
-    }
-}
+            header.innerHTML = `<h5>Change Login Mode</h5><button type="button" class="modal-close-btn" data-dismiss="modal" id="closeModal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`;
+            
+            const inputFields = generateInputFields(isPhone, participant);
+            const formButtons = generateFormButtons();
+            const template = `<div><form id="formResponse2" method="post">${inputFields}${formButtons}</form></div>`;
 
-// updates existing email or phone
-const updateUserLogin = (participant, bearerToken) => {
-    const switchSiginButton = document.getElementById('updateUserLogin');
-    const isPhone = getIsPhone(participant[fieldMapping.signInMechansim]);
-    const isEmail = getIsEmail(participant[fieldMapping.signInMechansim]); 
-    let updateFlag = ``
-    let template = ``
-    if (switchSiginButton) {
-        switchSiginButton.addEventListener('click', () => {
-            const header = document.getElementById('modalHeader');
-            const body = document.getElementById('modalBody');
-            header.innerHTML = `<h5>Change Login ${isPhone ? `Phone` : `Email`}</h5><button type="button" class="modal-close-btn" data-dismiss="modal" id="closeModal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
-            template = `<div> <form id="formResponse2" method="post"> `
-            if (isPhone) {
-                template +=  `<div class="form-group">
-                            <label class="col-form-label search-label">Current Login</label>
-                            <input class="form-control" value=${participant[fieldMapping.accountPhone]} disabled/>
-                            <label class="col-form-label search-label">Enter New Phone Login</label>
-                            <input class="form-control" id="newPhone" placeholder="Enter phone number without dashes & parenthesis"/>
-                            <label class="col-form-label search-label">Confirm New Phone Login</label>
-                            <input class="form-control" id="confirmPhone" placeholder="Confim phone number"/>
-                        </div>`
-                updateFlag = `updatePhone`
-
-            }
-            else if (isEmail) {
-                template +=  `<div class="form-group">
-                            <label class="col-form-label search-label">Current Login</label>
-                            <input class="form-control" value=${participant[fieldMapping.accountEmail]} disabled/>
-                            <label class="col-form-label search-label">Enter New Email Login</label>
-                            <input class="form-control" type="email" id="newEmail" placeholder="Enter Email"/>
-                            <label class="col-form-label search-label">Confirm New Email Login</label>
-                            <input class="form-control" type="email" id="confirmEmail" placeholder="Confim Email"/>
-                        </div>`
-                updateFlag = `updateEmail`
-            }
-            template += `<div class="form-group">
-                            <button type="submit" class="btn btn-danger" data-dismiss="modal" target="_blank">Cancel</button>
-                            <button type="submit" class="btn btn-primary" data-toggle="modal">Submit</button>
-                        </div>
-                    </form>
-                </div>`
             body.innerHTML = template;
-            let prevCounter =  appState.getState().unsavedChangesTrack.counter
+
+            let prevCounter = appState.getState().unsavedChangesTrack.counter;
             appState.setState({unsavedChangesTrack:{saveFlag: false, counter: prevCounter+1}});
-            processSwitchSigninMechanism(participant, bearerToken, updateFlag);
+            processSwitchSigninMechanism(participant, siteKey, 'replaceSignin');
         })
     }
 }
@@ -439,8 +349,7 @@ const processSwitchSigninMechanism = (participant, bearerToken, flag) => {
         if (confirmation) {
             const phoneField = document.getElementById('newPhone');
             const emailField = document.getElementById('newEmail');
-            if(phoneField && phoneField.value === document.getElementById('confirmPhone').value) {
-
+            if (phoneField && phoneField.value === document.getElementById('confirmPhone').value) {
                 (phoneField.value.toString().length) === 10 ? 
                 tweakedPhoneNumber = phoneField.value.toString().trim()
                 : tweakedPhoneNumber = phoneField.value.toString().slice(2).trim()
@@ -448,15 +357,11 @@ const processSwitchSigninMechanism = (participant, bearerToken, flag) => {
                 switchPackage['phone'] = tweakedPhoneNumber
                 changedOption[fieldMapping.signInMechansim] = 'phone'
                 changedOption[fieldMapping.accountPhone] = `+1`+tweakedPhoneNumber
-            }
-
-            else if (emailField &&  emailField.value === document.getElementById('confirmEmail').value) {
+            } else if (emailField &&  emailField.value === document.getElementById('confirmEmail').value) {
                 switchPackage['email'] = emailField.value 
                 changedOption[fieldMapping.signInMechansim] = 'password'
                 changedOption[fieldMapping.accountEmail] = emailField.value
-            }
-
-            else {
+            } else {
                 alert(`Your entered inputs don't match`)
                 return
             }
@@ -469,8 +374,7 @@ const processSwitchSigninMechanism = (participant, bearerToken, flag) => {
     })
 };
 
-// async-await function to make HTTP POST request
-const switchSigninMechanismHandler = async (switchPackage, bearerToken, changedOption) =>  {
+const switchSigninMechanismHandler = async (switchPackage, siteKey, changedOption) =>  {
     showAnimation();
 
     const signinMechanismPayload = {
@@ -481,80 +385,99 @@ const switchSigninMechanismHandler = async (switchPackage, bearerToken, changedO
         method:'POST',
         body: JSON.stringify(signinMechanismPayload),
         headers:{
-            Authorization:"Bearer " + bearerToken,
+            Authorization:"Bearer " + siteKey,
             "Content-Type": "application/json"
             }
-        })
+        });
         hideAnimation();
-
+        console.log('response', response);
         if (response.status === 200) {
-            const isSuccess = await signInMechanismClickHandler(changedOption, bearerToken);
+            const isSuccess = await signInMechanismClickHandler(changedOption, siteKey);
 
             if (!isSuccess) {
-                let alertList = document.getElementById("alert_placeholder");
-                let template = ``;
-                template += `
-                        <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                          Operation failed!
-                          <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                                    <span aria-hidden="true">&times;</span>
-                                </button>
-                        </div>`;
-                alertList.innerHTML = template;
+                showAPIAlert('danger', 'Operation failed!');
                 return;
             }
-
-            let alertList = document.getElementById("alert_placeholder");
-            let template = ``;
-            template += `
-                    <div class="alert alert-success alert-dismissible fade show" role="alert">
-                      Operation successful!
-                      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                    </div>`;
-            alertList.innerHTML = template;
-            
+            showAPIAlert('success', 'Operation successful!');
             closeModal();
-            
-            const changeLoginModeText = document.getElementById('Change Login Moderow').children[1];
+
+            //const changeLoginModeText = document.getElementById('Change Login Moderow').children[1];
             const changeLoginEmailRow = document.getElementById('Change Login Emailrow');
             const changeLoginPhoneRow = document.getElementById('Change Login Phonerow');
 
-            if (switchPackage.flag === "updatePhone" || switchPackage.flag === "updateEmail" || switchPackage.flag === "replaceSignin") {
-                changeLoginModeText.innerHTML = 'Updating login';
+            if (["updatePhone", "updateEmail", "replaceSignin"].includes(switchPackage.flag)) {
+                //changeLoginModeText.innerHTML = 'Updating login';
                 if (changeLoginPhoneRow) changeLoginPhoneRow.children[1].innerHTML = 'Updating phone number';
                 if (changeLoginEmailRow) changeLoginEmailRow.children[1].innerHTML = 'Updating email';
             }
-
-            await reloadParticipantData(changedOption.token, bearerToken);
+            await reloadParticipantData(changedOption.token, siteKey);
+        } else if (response.status === 409) {
+            showAPIError('modalBody', switchPackage.phone ? 'Phone Number already in use!' : 'Email already in use!');
+        } else if (response.status === 403) {
+            showAPIError('modalBody', switchPackage.phone ? 'Invalid Phone Number!' : 'Invalid Email!');
+        } else { 
+            showAPIError('modalBody', 'Operation Unsuccessful!');
         }
-
-        else if (response.status === 409) {
-            const body = document.getElementById('modalBody');
-            let template = ``
-            if (switchPackage.phone) template += '<div>Phone Number already in use!</div>'
-            else template += '<div>Email already in use!</div>'
-            body.innerHTML = template;
-            return false;
-        }
-
-        else if (response.status === 403) {
-            const body = document.getElementById('modalBody');
-            let template = ``
-            if (switchPackage.phone) template += '<div>Invalid Phone Number!</div>' 
-            else template += '<div>Invalid Email!</div>'
-            body.innerHTML = template;
-            return false;
-         }
-
-        else { 
-            const body = document.getElementById('modalBody');
-            body.innerHTML = `Operation Unsuccessful!`;
-            return false;
-        }
+    } catch (error) {
+        console.error('Fetch Error:', error);
+        hideAnimation();
+        showAPIError('modalBody', 'Operation Unsuccessful!');
+    }
 }
 
+// async-await function to make HTTP POST request
+async function signInMechanismClickHandler(updatedOptions, siteKey)  {
+
+    const updateParticpantPayload = {
+        "data": [updatedOptions]
+    }
+
+    try {
+        showAnimation();
+        const response = await fetch(`${baseAPI}/dashboard?api=updateParticipantData`,{
+            method:'POST',
+            body: JSON.stringify(updateParticpantPayload),
+            headers:{
+                Authorization: "Bearer " + siteKey,
+                "Content-Type": "application/json"
+            }
+        });
+        hideAnimation();
+        console.log('response', response);
+        if (response.status === 200) {
+            document.getElementById('loadingAnimation').style.display = 'none';
+            appState.setState({unsavedChangesTrack:{saveFlag: true, counter: 0}});
+            showAPIAlert('success', 'Participant detail updated!');
+            return true;
+        } else { 
+            throw new Error('Error: (signInMechanismClickHandler())');
+        }
+    } catch (error) {
+        console.error('Error in updating participant data (signInMechanismClickHandler())', error);
+        hideAnimation();
+        alert('Error in updating participant data. Please try again.');
+        return false;
+    }
+}
+
+const showAPIAlert = (type, message) => {
+    const alertList = document.getElementById("alert_placeholder");
+    alertList.innerHTML = `
+        <div class="alert alert-${type} alert-dismissible fade show" role="alert">
+            ${message}
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+            </button>
+        </div>`;
+}
+
+const showAPIError = (bodyId, message) => {
+    const body = document.getElementById(bodyId);
+    body.innerHTML = `<div>${message}</div>`;
+    return false;
+}
+
+//TODO consider routing
 const renderBackToSearchDivAndButton = () => {
     return `
         <div class="float-left">
@@ -724,4 +647,227 @@ const renderSuffixSelector = (participant, participantValue, conceptId) => {
         </select>
         `
 };
-  
+// async function signInMechanismClickHandler(updatedOptions, siteKey)  {
+//     try {
+//         showAnimation();
+
+//         const updateParticpantPayload = {
+//             "data": [updatedOptions]
+//         }
+
+//         const response = await fetch(`${baseAPI}/dashboard?api=updateParticipantData`,{
+//             method:'POST',
+//             body: JSON.stringify(updateParticpantPayload),
+//             headers:{
+//                 Authorization:"Bearer " + siteKey,
+//                 "Content-Type": "application/json"
+//                 }
+//         });
+//         hideAnimation();
+
+//         if (response.status === 200) {
+//             document.getElementById('loadingAnimation').style.display = 'none';
+//             appState.setState({unsavedChangesTrack:{saveFlag: true, counter: 0}})
+//             let alertList = document.getElementById("alert_placeholder");
+//             let template = ``;
+//             template += `
+//                     <div class="alert alert-success alert-dismissible fade show" role="alert">
+//                     Participant detail updated!
+//                         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+//                                 <span aria-hidden="true">&times;</span>
+//                             </button>
+//                     </div>`;
+//             alertList.innerHTML = template;
+//             return true;
+//         } else { 
+//             throw new Error('Error: (signInMechanismClickHandler())');
+//         }
+//     } catch (error) {
+//         console.error('Error in updating participant data (signInMechanismClickHandler())', error);
+//         hideAnimation();
+//         alert('Error in updating participant data. Please try again.');
+//         return false;
+//     }
+// }
+//const switchSiginButton = document.getElementById('switchSiginMechanism');
+
+// const updateUserSigninMechanism = (participant, siteKey) => {
+//     const switchSiginButton = document.getElementById('updateUserLogin');
+//     const isPhone = getIsPhone(participant[fieldMapping.signInMechansim]);
+//     const isEmail = getIsEmail(participant[fieldMapping.signInMechansim]); 
+//     let template = ``
+//     if (switchSiginButton) {
+//         switchSiginButton.addEventListener('click', () => {
+//             const header = document.getElementById('modalHeader');
+//             const body = document.getElementById('modalBody');
+//             header.innerHTML = `<h5>Change Login Mode</h5><button type="button" class="modal-close-btn" data-dismiss="modal" id="closeModal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
+//             template = `<div> <form id="formResponse2" method="post"> `
+//             if (isPhone) {
+//                 template +=  `<div class="form-group">
+//                             <label class="col-form-label search-label">Current Login</label>
+//                             <input class="form-control" value=${participant[fieldMapping.accountPhone]} disabled/>
+//                             <label class="col-form-label search-label">Enter New Email Login</label>
+//                             <input class="form-control" type="email" id="newEmail" placeholder="Enter Email"/>
+//                             <label class="col-form-label search-label">Confirm New Email Login</label>
+//                             <input class="form-control" type="email" id="confirmEmail" placeholder="Confim Email"/>
+//                         </div>`
+//             }
+//             else if (isEmail) {
+//                 template +=  `<div class="form-group">
+//                             <label class="col-form-label search-label">Current Login</label>
+//                             <input class="form-control" value=${participant[fieldMapping.accountEmail]} disabled/>
+//                             <label class="col-form-label search-label">Enter New Phone Login</label>
+//                             <input class="form-control" id="newPhone" placeholder="Enter phone number without dashes & parenthesis"/>
+//                             <label class="col-form-label search-label">Confirm New Phone Login</label>
+//                             <input class="form-control" id="confirmPhone" placeholder="Confim phone number"/>
+//                         </div>`
+//             }
+//             template += `<div class="form-group">
+//                             <button type="submit" class="btn btn-danger" data-dismiss="modal" target="_blank">Cancel</button>
+//                             <button type="submit" class="btn btn-primary" data-toggle="modal">Submit</button>
+//                         </div>
+//                     </form>
+//                 </div>`
+//             body.innerHTML = template;
+//             let prevCounter =  appState.getState().unsavedChangesTrack.counter
+//             appState.setState({unsavedChangesTrack:{saveFlag: false, counter: prevCounter+1}});
+//             processSwitchSigninMechanism(participant, siteKey, 'replaceSignin');
+//         })
+//     }
+// }
+
+// // updates existing email or phone
+// const updateUserLogin = (participant, siteKey) => {
+//     const switchSiginButton = document.getElementById('updateUserLogin');
+//     const isPhone = getIsPhone(participant[fieldMapping.signInMechansim]);
+//     const isEmail = getIsEmail(participant[fieldMapping.signInMechansim]); 
+//     let updateFlag = ``
+//     let template = ``
+//     if (switchSiginButton) {
+//         switchSiginButton.addEventListener('click', () => {
+//             const header = document.getElementById('modalHeader');
+//             const body = document.getElementById('modalBody');
+//             header.innerHTML = `<h5>Change Login ${isPhone ? 'Phone' : 'Email'}</h5><button type="button" class="modal-close-btn" data-dismiss="modal" id="closeModal" aria-label="Close"><span aria-hidden="true">&times;</span></button>`
+//             template = `<div> <form id="formResponse2" method="post"> `
+//             if (isPhone) {
+//                 template +=  `<div class="form-group">
+//                             <label class="col-form-label search-label">Current Login</label>
+//                             <input class="form-control" value=${participant[fieldMapping.accountPhone]} disabled/>
+//                             <label class="col-form-label search-label">Enter New Phone Login</label>
+//                             <input class="form-control" id="newPhone" placeholder="Enter phone number without dashes & parenthesis"/>
+//                             <label class="col-form-label search-label">Confirm New Phone Login</label>
+//                             <input class="form-control" id="confirmPhone" placeholder="Confim phone number"/>
+//                         </div>`
+//                 updateFlag = `updatePhone`
+
+//             }
+//             else if (isEmail) {
+//                 template +=  `<div class="form-group">
+//                             <label class="col-form-label search-label">Current Login</label>
+//                             <input class="form-control" value=${participant[fieldMapping.accountEmail]} disabled/>
+//                             <label class="col-form-label search-label">Enter New Email Login</label>
+//                             <input class="form-control" type="email" id="newEmail" placeholder="Enter Email"/>
+//                             <label class="col-form-label search-label">Confirm New Email Login</label>
+//                             <input class="form-control" type="email" id="confirmEmail" placeholder="Confim Email"/>
+//                         </div>`
+//                 updateFlag = `updateEmail`
+//             }
+//             template += `<div class="form-group">
+//                             <button type="submit" class="btn btn-danger" data-dismiss="modal" target="_blank">Cancel</button>
+//                             <button type="submit" class="btn btn-primary" data-toggle="modal">Submit</button>
+//                         </div>
+//                     </form>
+//                 </div>`
+//             body.innerHTML = template;
+//             let prevCounter =  appState.getState().unsavedChangesTrack.counter
+//             appState.setState({unsavedChangesTrack:{saveFlag: false, counter: prevCounter+1}});
+//             processSwitchSigninMechanism(participant, siteKey, updateFlag);
+//         })
+//     }
+// }
+
+// async-await function to make HTTP POST request
+// const switchSigninMechanismHandler = async (switchPackage, siteKey, changedOption) =>  {
+//     showAnimation();
+
+//     const signinMechanismPayload = {
+//         "data": switchPackage
+//     }
+
+//     const response = await fetch(`${baseAPI}/dashboard?api=updateUserAuthentication`,{
+//         method:'POST',
+//         body: JSON.stringify(signinMechanismPayload),
+//         headers:{
+//             Authorization:"Bearer " + siteKey,
+//             "Content-Type": "application/json"
+//             }
+//         })
+//         hideAnimation();
+
+//         if (response.status === 200) {
+//             const isSuccess = await signInMechanismClickHandler(changedOption, siteKey);
+
+//             if (!isSuccess) {
+//                 let alertList = document.getElementById("alert_placeholder");
+//                 let template = ``;
+//                 template += `
+//                         <div class="alert alert-danger alert-dismissible fade show" role="alert">
+//                           Operation failed!
+//                           <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+//                                     <span aria-hidden="true">&times;</span>
+//                                 </button>
+//                         </div>`;
+//                 alertList.innerHTML = template;
+//                 return;
+//             }
+
+//             let alertList = document.getElementById("alert_placeholder");
+//             let template = ``;
+//             template += `
+//                     <div class="alert alert-success alert-dismissible fade show" role="alert">
+//                       Operation successful!
+//                       <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+//                                 <span aria-hidden="true">&times;</span>
+//                             </button>
+//                     </div>`;
+//             alertList.innerHTML = template;
+            
+//             closeModal();
+            
+//             const changeLoginModeText = document.getElementById('Change Login Moderow').children[1];
+//             const changeLoginEmailRow = document.getElementById('Change Login Emailrow');
+//             const changeLoginPhoneRow = document.getElementById('Change Login Phonerow');
+
+//             if (switchPackage.flag === "updatePhone" || switchPackage.flag === "updateEmail" || switchPackage.flag === "replaceSignin") {
+//                 changeLoginModeText.innerHTML = 'Updating login';
+//                 if (changeLoginPhoneRow) changeLoginPhoneRow.children[1].innerHTML = 'Updating phone number';
+//                 if (changeLoginEmailRow) changeLoginEmailRow.children[1].innerHTML = 'Updating email';
+//             }
+
+//             await reloadParticipantData(changedOption.token, siteKey);
+//         }
+
+//         else if (response.status === 409) {
+//             const body = document.getElementById('modalBody');
+//             let template = ``
+//             if (switchPackage.phone) template += '<div>Phone Number already in use!</div>'
+//             else template += '<div>Email already in use!</div>'
+//             body.innerHTML = template;
+//             return false;
+//         }
+
+//         else if (response.status === 403) {
+//             const body = document.getElementById('modalBody');
+//             let template = ``
+//             if (switchPackage.phone) template += '<div>Invalid Phone Number!</div>' 
+//             else template += '<div>Invalid Email!</div>'
+//             body.innerHTML = template;
+//             return false;
+//          }
+
+//         else { 
+//             const body = document.getElementById('modalBody');
+//             body.innerHTML = `Operation Unsuccessful!`;
+//             return false;
+//         }
+//}

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -72,9 +72,10 @@ export const render = (participant, changedOption) => {
             const variableLabel = row.label;
             const variableValue = participant[conceptId];
             const valueToRender = getFieldValues(variableValue, conceptId);
+            const loginEditMemoRowBackgroundColor = conceptId === 'Login Update Memo' ? '#f5f5f5' : null;
             const buttonToRender = getButtonToRender(variableLabel, conceptId, participant[fieldMapping.dataDestroyCategorical]);
             template += `
-                <tr class="detailedRow" style="text-align: left;" id="${conceptId}row"}>
+                <tr class="detailedRow" style="text-align: left; background-color: ${loginEditMemoRowBackgroundColor}" id="${conceptId}row">
                     <th scope="row">
                         <div class="mb-3">
                             <label class="form-label">

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -1,5 +1,5 @@
 import { dashboardNavBarLinks, removeActiveClass } from './navigationBar.js';
-import { attachUpdateLoginMethodListeners, allStates, closeModal, formatInputResponse, getFieldValues, getImportantRows, getModalLabel, hideUneditableButtons, renderReturnSearchResults, resetChanges, saveResponses, showSaveNoteInModal, submitClickHandler, suffixList, viewParticipantSummary, } from './participantDetailsHelpers.js';
+import { attachUpdateLoginMethodListeners, allStates, closeModal, getFieldValues, getImportantRows, getModalLabel, hideUneditableButtons, renderReturnSearchResults, resetChanges, saveResponses, showSaveNoteInModal, submitClickHandler, suffixList, viewParticipantSummary, } from './participantDetailsHelpers.js';
 import fieldMapping from './fieldToConceptIdMapping.js'; 
 import { renderParticipantHeader } from './participantHeader.js';
 import { getDataAttributes } from './utils.js';
@@ -22,14 +22,12 @@ window.addEventListener('onload', (e) => {
 })
 
 const initLoginMechanism = (participant) => {
-    participant['Change Login Phone'] = participant[fieldMapping.accountPhone];
-    participant['Change Login Email'] = participant[fieldMapping.accountEmail]; 
+    participant['Change Login Phone'] = participant[fieldMapping.accountPhone] ?? '';
+    participant['Change Login Email'] = participant[fieldMapping.accountEmail] ?? ''; 
     appState.setState({loginMechanism:{phone: true, email: true}});
 }
 
 export const renderParticipantDetails = (participant, changedOption, bearerToken) => {
-    console.log('participantToken', participant.token);
-    console.log('bearer token:', bearerToken);
     initLoginMechanism(participant);
     const isParent = localStorage.getItem('isParent');
     document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks(isParent);
@@ -273,7 +271,6 @@ const saveAltResponse = (participant) => {
     })
 }
 
-//TODO consider routing
 const renderBackToSearchDivAndButton = () => {
     return `
         <div class="float-left">

--- a/siteManagerDashboard/participantDetails.js
+++ b/siteManagerDashboard/participantDetails.js
@@ -27,7 +27,7 @@ const initLoginMechanism = (participant) => {
     appState.setState({loginMechanism:{phone: true, email: true}});
 }
 
-export const renderParticipantDetails = (participant, changedOption, bearerToken) => {
+export const renderParticipantDetails = (participant, changedOption) => {
     initLoginMechanism(participant);
     const isParent = localStorage.getItem('isParent');
     document.getElementById('navBarLinks').innerHTML = dashboardNavBarLinks(isParent);
@@ -37,12 +37,12 @@ export const renderParticipantDetails = (participant, changedOption, bearerToken
     let originalHTML =  mainContent.innerHTML;
     hideUneditableButtons(participant, changedOption);
     localStorage.setItem("participant", JSON.stringify(participant));
-    changeParticipantDetail(participant,  changedOption, originalHTML, bearerToken);
+    changeParticipantDetail(participant,  changedOption, originalHTML);
     editAltContact(participant);
     viewParticipantSummary(participant);
     renderReturnSearchResults();
-    attachUpdateLoginMethodListeners(participant[fieldMapping.accountEmail], participant[fieldMapping.accountPhone], participant.token, participant.state.uid, bearerToken);
-    submitClickHandler(participant, changedOption, bearerToken);
+    attachUpdateLoginMethodListeners(participant[fieldMapping.accountEmail], participant[fieldMapping.accountPhone], participant.token, participant.state.uid);
+    submitClickHandler(participant, changedOption);
 }
 
 export const render = (participant, changedOption) => {
@@ -72,7 +72,7 @@ export const render = (participant, changedOption) => {
             const variableLabel = row.label;
             const variableValue = participant[conceptId];
             const valueToRender = getFieldValues(variableValue, conceptId);
-            const buttonToRender = getButtonToRender(variableLabel, conceptId);
+            const buttonToRender = getButtonToRender(variableLabel, conceptId, participant[fieldMapping.dataDestroyCategorical]);
             template += `
                 <tr class="detailedRow" style="text-align: left;" id="${conceptId}row"}>
                     <th scope="row">
@@ -106,7 +106,7 @@ export const render = (participant, changedOption) => {
     return template;
 }
 
-const changeParticipantDetail = (participant, changedOption, originalHTML, bearerToken) => {
+const changeParticipantDetail = (participant, changedOption, originalHTML) => {
     const detailedRow = Array.from(document.getElementsByClassName('detailedRow'));
     if (detailedRow) {
         detailedRow.forEach(element => {
@@ -130,7 +130,7 @@ const changeParticipantDetail = (participant, changedOption, originalHTML, beare
                 body.innerHTML = template;
                 showSaveNoteInModal(conceptId);
                 saveResponses(participant, changedOption, element, conceptId);
-                resetChanges(participant, originalHTML, bearerToken);   
+                resetChanges(participant, originalHTML);   
             });
         })
     }
@@ -142,8 +142,9 @@ const changeParticipantDetail = (participant, changedOption, originalHTML, beare
  * @param {string} conceptId - the conceptId of the variable 
  * @returns {HTMLButtonElement} - template string with the button to render
  */
-const getButtonToRender = (variableLabel, conceptId) => {
-    const loginButtonType = conceptId === 'Change Login Phone' ? 'Phone' : conceptId === 'Change Login Email' ? 'Email' : null;
+const getButtonToRender = (variableLabel, conceptId, participantIsDataDestroyed) => {
+    const isParticipantDataDestroyed = participantIsDataDestroyed === fieldMapping.requestedDataDestroySigned;
+    const loginButtonType = !isParticipantDataDestroyed && conceptId === 'Change Login Phone' ? 'Phone' : !isParticipantDataDestroyed && conceptId === 'Change Login Email' ? 'Email' : null;
     const participantKey = loginButtonType ? '' : `data-participantkey="${variableLabel}"`;
     const participantConceptId = loginButtonType ? '' : `data-participantconceptid="${conceptId}"`;
     const participantLoginUpdate = loginButtonType ? `data-participantLoginUpdate="${loginButtonType.toLowerCase()}"` : '';

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -1113,12 +1113,8 @@ export const submitClickHandler = async (participant, changedOption) => {
                 alert('No changes to submit. No changes have been made. Please update the form and try again if changes are needed.');
             } else {
                 let { changedUserDataForProfile, changedUserDataForHistory } = findChangedUserDataValues(changedOption, participant);
-                if (phoneTypes.some(phoneKey => phoneKey in changedUserDataForProfile)) {
-                    changedUserDataForProfile = handleAllPhoneNoField(changedUserDataForProfile, participant);
-                }
-                if (emailTypes.some(emailKey => emailKey in changedUserDataForProfile)) {
-                    changedUserDataForProfile = handleAllEmailField(changedUserDataForProfile, participant);
-                }
+                if (phoneTypes.some(phoneKey => phoneKey in changedUserDataForProfile)) changedUserDataForProfile = handleAllPhoneNoField(changedUserDataForProfile, participant);
+                if (emailTypes.some(emailKey => emailKey in changedUserDataForProfile)) changedUserDataForProfile = handleAllEmailField(changedUserDataForProfile, participant);
                 const isSuccess = processUserDataUpdate(changedUserDataForProfile, changedUserDataForHistory, participant[fieldMapping.userProfileHistory], participant.state.uid, adminEmail, isParticipantVerified);
                 if (isSuccess) {
                     const updatedParticipant = { ...participant, ...changedUserDataForProfile};

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -98,14 +98,6 @@ export const getFieldValues = (variableValue, conceptId) => {
     else return variableValue;
 }
 
-export const formatInputResponse = (participantValue) => {
-    let ptValue = '';
-    if (participantValue !== undefined) {
-        ptValue  = participantValue.toString().replace(/\s+/g, "")
-    }
-    return ptValue;
-};
-
 export const formatPhoneNumber = (phoneNumber) => {
     if (!phoneNumber) return '';
     if (/^\+1/.test(phoneNumber)) {
@@ -467,21 +459,18 @@ export const attachUpdateLoginMethodListeners = (participantAuthenticationEmail,
             };
             const inputFields = generateLoginFormInputFields(currentLogins, loginType);
             const formButtons = generateAuthenticationFormButtons(!!(currentLogins.email && !currentLogins.email.startsWith('noReply')), !!currentLogins.phone, loginType);
-            const template = `
+            body.innerHTML = `
                 <div>
                     <form id="authDataForm" method="post">
                         ${inputFields}${formButtons}
                     </form>
                 </div>`;
-            body.innerHTML = template;
 
             const formResponse = document.getElementById('authDataForm');
             if (formResponse) {
                 formResponse.addEventListener('submit', async (e) => {
                     e.preventDefault();
-                    let switchPackage = {};
-                    let changedOption = {};
-                    ({ switchPackage, changedOption } = getUpdatedAuthenticationFormValues(participantAuthenticationEmail, participantAuthenticationPhone));
+                    const { switchPackage, changedOption } = getUpdatedAuthenticationFormValues(participantAuthenticationEmail, participantAuthenticationPhone);
                     if (switchPackage && changedOption) {
                         await processParticipantLoginMethod(participantAuthenticationEmail, participantToken, participantUid, bearerToken, switchPackage, changedOption, 'update');
                     }
@@ -580,7 +569,7 @@ const getUpdatedAuthenticationFormValues = (participantAuthenticationEmail, part
     } else if (emailField &&  emailField.value === document.getElementById('confirmEmail').value) {
         if (!validEmailFormat.test(emailField.value)) {
             alert('Invalid email format. Please enter a valid email address in the format: abc@example.com');
-            return;
+            return {}, {};
         }
         switchPackage['email'] = emailField.value;
         switchPackage['flag'] = 'updateEmail'; 
@@ -693,7 +682,7 @@ const updateParticipantFirestoreProfile = async (updatedOptions, bearerToken) =>
 
 const postLoginData = async (url = '', data = {}, bearerToken) => {
     try {
-        const response = await fetch(url, {
+        return await fetch(url, {
             method: 'POST',
             body: JSON.stringify(data),
             headers: {
@@ -701,7 +690,6 @@ const postLoginData = async (url = '', data = {}, bearerToken) => {
                 'Authorization': `Bearer ${bearerToken}`
             }
         });
-        return response;
     } catch (error) {
         console.error('Fetch Error:', error);
         throw error;

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -296,12 +296,12 @@ export const getImportantRows = (participant, changedOption) => {
     ];
 
     const loginChangeInfoArray = [
-        { field: `Change Login Mode`,
-            label: 'Change Login Mode',
-            editable: true,
-            display: true,
-            validationType: 'none'
-        },
+        // { field: `Change Login Mode`,
+        //     label: 'Change Login Mode',
+        //     editable: true,
+        //     display: true,
+        //     validationType: 'none'
+        // },
         { field: `Change Login Email`,
             label: 'Change Login Email',
             editable: true,
@@ -432,6 +432,7 @@ export const renderReturnSearchResults = () => {
     const searchResultsButton = document.getElementById('displaySearchResultsBtn');
     if (searchResultsButton) {
         searchResultsButton.addEventListener('click', () => {
+            //renderParticipantLookup()
             renderLookupResultsTable();
         })
 }};

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -3,7 +3,7 @@ import { render, renderParticipantDetails } from './participantDetails.js';
 import { findParticipant, renderLookupResultsTable } from './participantLookup.js';
 import { renderParticipantSummary } from './participantSummary.js';
 import { appState } from './stateManager.js';
-import { baseAPI, getDataAttributes, getIdToken, hideAnimation, showAnimation } from './utils.js';
+import { baseAPI, getAccessToken, getDataAttributes, getIdToken, hideAnimation, showAnimation } from './utils.js';
 
 export const allStates = {
     "Alabama":1,
@@ -112,167 +112,168 @@ const isPhoneNumberInForm = (participant, changedOption, fieldMappingKey) => {
 
 export const getImportantRows = (participant, changedOption) => {
     const isParticipantVerified = participant[fieldMapping.verifiedFlag] === fieldMapping.verified;
+    const isParticipantDataDestroyed = participant[fieldMapping.dataDestroyCategorical] === fieldMapping.requestedDataDestroySigned;
     const isCellPhonePresent = isPhoneNumberInForm(participant, changedOption, fieldMapping.cellPhone);
     const isHomePhonePresent = isPhoneNumberInForm(participant, changedOption, fieldMapping.homePhone);
     const isOtherPhonePresent = isPhoneNumberInForm(participant, changedOption, fieldMapping.otherPhone);
     const importantRowsArray = [ 
         { field: fieldMapping.lName,
             label: 'Last Name',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'text',
             isRequired: true
         },
         { field: fieldMapping.fName,
             label: 'First Name',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'text',
             isRequired: true
         },
         { field: fieldMapping.prefName,
             label: 'Preferred Name',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'text',
             isRequired: false
         },
         { field: fieldMapping.mName,
             label: 'Middle Name',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'text',
             isRequired: false
         },
         { field: fieldMapping.suffix,
             label: 'Suffix',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'suffix',
             isRequired: false
         },
         { field: fieldMapping.cellPhone,
             label: 'Cell Phone',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'phoneNumber',
             isRequired: false
         },
         { field: fieldMapping.canWeText,
             label: 'Can we text your mobile phone?',
-            editable: isCellPhonePresent,
+            editable: !isParticipantDataDestroyed && isCellPhonePresent,
             display: true,
             validationType: 'permissionSelector',
             isRequired: false
         },
         { field: fieldMapping.voicemailMobile,
             label: 'Can we leave a voicemail at your mobile phone number?',
-            editable: isCellPhonePresent,
+            editable: !isParticipantDataDestroyed && isCellPhonePresent,
             display: true,
             validationType: 'permissionSelector',
             isRequired: false
         },
         { field: fieldMapping.homePhone,
             label: 'Home Phone',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'phoneNumber',
             isRequired: false
         },
         { field: fieldMapping.voicemailHome,
             label: 'Can we leave a voicemail at your home phone number?',
-            editable: isHomePhonePresent,
+            editable: !isParticipantDataDestroyed && isHomePhonePresent,
             display: true,
             validationType: 'permissionSelector',
             isRequired: false
         },
         { field: fieldMapping.otherPhone,
             label: 'Other Phone',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'phoneNumber',
             isRequired: false
         },
         { field: fieldMapping.voicemailOther,
             label: '   Can we leave a voicemail at your other phone number?',
-            editable: isOtherPhonePresent,
+            editable: !isParticipantDataDestroyed && isOtherPhonePresent,
             display: true,
             validationType: 'permissionSelector',
             isRequired: false
         },
         { field: fieldMapping.email,
             label: 'Preferred Email',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'email',
             isRequired: true
         },
         { field: fieldMapping.email1,
             label: 'Additional Email 1',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'email',
             isRequired: false
         },
         { field: fieldMapping.email2,
             label: 'Additional Email 2',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'email',
             isRequired: false
         },
         { field: fieldMapping.address1,
             label: 'Address Line 1',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'address',
             isRequired: true
         },
         { field: fieldMapping.address2,
             label: 'Address Line 2',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'address',
             isRequired: false
         },
         { field: fieldMapping.city,
             label: 'City',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'text',
             isRequired: true
         },
         { field: fieldMapping.state,
             label: 'State',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'state',
             isRequired: true
         },
         { field: fieldMapping.zip,
             label: 'Zip',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: true,
             validationType: 'zip',
             isRequired: true
         },
         { field: fieldMapping.birthMonth,
             label: 'Birth Month',
-            editable: !isParticipantVerified,
+            editable: !isParticipantDataDestroyed && !isParticipantVerified,
             display: !isParticipantVerified,
             validationType: 'month',
             isRequired: true
         },
         { field: fieldMapping.birthDay,
             label: 'Birth Day',
-            editable: !isParticipantVerified,
+            editable: !isParticipantDataDestroyed && !isParticipantVerified,
             display: !isParticipantVerified,
             validationType: 'day',
             isRequired: true
         },
         { field: fieldMapping.birthYear,
             label: 'Birth Year',
-            editable: !isParticipantVerified,
+            editable: !isParticipantDataDestroyed && !isParticipantVerified,
             display: !isParticipantVerified,
             validationType: 'year',
             isRequired: true
@@ -289,13 +290,13 @@ export const getImportantRows = (participant, changedOption) => {
     const loginChangeInfoArray = [
         { field: `Change Login Email`,
             label: 'Email Login',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display: appState.getState().loginMechanism.email,
             validationType: 'none'
         },
         { field: `Change Login Phone`,
             label: 'Phone Login',
-            editable: true,
+            editable: !isParticipantDataDestroyed,
             display:  appState.getState().loginMechanism.phone,
             validationType: 'none'
         }
@@ -390,12 +391,12 @@ export const hideUneditableButtons = (participant, changedOption) => {
     })
 };
 
-export const reloadParticipantData = async (token, bearerToken) => {
+export const reloadParticipantData = async (token) => {
     showAnimation();
     const query = `token=${token}`
     const reloadedParticpant = await findParticipant(query);
     mainContent.innerHTML = render(reloadedParticpant.data[0]);
-    renderParticipantDetails(reloadedParticpant.data[0], {}, bearerToken);
+    renderParticipantDetails(reloadedParticpant.data[0], {});
     hideAnimation();
 }
 
@@ -413,13 +414,13 @@ export const renderReturnSearchResults = () => {
         })
 }};
 
-export const resetChanges = (participant, originalHTML, bearerToken) => {
+export const resetChanges = (participant, originalHTML) => {
     const a = document.getElementById("cancelChanges");
     let template = '';
     a.addEventListener("click", () => {
         if ( appState.getState().unsavedChangesTrack.saveFlag === false ) {
             mainContent.innerHTML = originalHTML;
-            renderParticipantDetails(participant, {}, bearerToken);
+            renderParticipantDetails(participant, {});
             appState.setState({unsavedChangesTrack:{saveFlag: false, counter: 0}})
             let alertList = document.getElementById('alert_placeholder');
             // throws an alert when canncel changes button is clicked
@@ -442,7 +443,7 @@ export const resetChanges = (participant, originalHTML, bearerToken) => {
  * for login updates (email or phone), switch package and changedOption are generated from the form
  * for login removal, switch package and changedOption are generated from the participant object
  */
-export const attachUpdateLoginMethodListeners = (participantAuthenticationEmail, participantAuthenticationPhone, participantToken, participantUid, bearerToken) => {
+export const attachUpdateLoginMethodListeners = (participantAuthenticationEmail, participantAuthenticationPhone, participantToken, participantUid) => {
     const createListener = (loginType) => {
         const typeName = capitalizeFirstLetter(loginType);
         return () => {
@@ -472,7 +473,7 @@ export const attachUpdateLoginMethodListeners = (participantAuthenticationEmail,
                     e.preventDefault();
                     const { switchPackage, changedOption } = getUpdatedAuthenticationFormValues(participantAuthenticationEmail, participantAuthenticationPhone);
                     if (switchPackage && changedOption) {
-                        await processParticipantLoginMethod(participantAuthenticationEmail, participantToken, participantUid, bearerToken, switchPackage, changedOption, 'update');
+                        await processParticipantLoginMethod(participantAuthenticationEmail, participantToken, participantUid, switchPackage, changedOption, 'update');
                     }
                 });
             }
@@ -481,7 +482,7 @@ export const attachUpdateLoginMethodListeners = (participantAuthenticationEmail,
                 const removeEmailLoginBtn = document.getElementById('removeUserLoginEmail');
                 if (removeEmailLoginBtn) {
                     removeEmailLoginBtn.addEventListener('click', async () => {
-                        await processParticipantLoginMethod(participantAuthenticationEmail, participantToken, participantUid, bearerToken, {}, {}, 'removeEmail');
+                        await processParticipantLoginMethod(participantAuthenticationEmail, participantToken, participantUid, {}, {}, 'removeEmail');
                     });
                 }
             }
@@ -490,15 +491,17 @@ export const attachUpdateLoginMethodListeners = (participantAuthenticationEmail,
                 const removePhoneLoginBtn = document.getElementById('removeUserLoginPhone');
                 if (removePhoneLoginBtn) {
                     removePhoneLoginBtn.addEventListener('click', async () => {
-                        await processParticipantLoginMethod(participantAuthenticationEmail, participantToken, participantUid, bearerToken,  {}, {}, 'removePhone');
+                        await processParticipantLoginMethod(participantAuthenticationEmail, participantToken, participantUid, {}, {}, 'removePhone');
                     });
                 }
             }
         };
     };
 
-    document.getElementById('updateUserLoginEmail').addEventListener('click', createListener('email'));
-    document.getElementById('updateUserLoginPhone').addEventListener('click', createListener('phone'));
+    const updateEmailButton = document.getElementById('updateUserLoginEmail');
+    const updatePhoneButton = document.getElementById('updateUserLoginPhone');
+    updateEmailButton && updateEmailButton.addEventListener('click', createListener('email'));
+    updatePhoneButton && updatePhoneButton.addEventListener('click', createListener('phone'));
 };
 
 const generateLoginFormInputFields = (currentLogins, loginType) => {
@@ -615,12 +618,11 @@ const getLoginRemovalSwitchPackage = (processType, participantAuthenticationEmai
  * @param {string} participantAuthenticationEmail - the participant's current email login 
  * @param {string} participantToken - the participant's current token
  * @param {string} participantUid - the participant's current uid
- * @param {string} bearerToken - the bearer token
  * @param {object} switchPackage - the data object sent to firebaseAuth to update the participant's login method
  * @param {object} changedOption - the data object sent to firestore to update the participant's login data
  * @param {string} processType - the type of process to be performed -> update, removeEmail, removePhone
  */
-const processParticipantLoginMethod = async (participantAuthenticationEmail, participantToken, participantUid, bearerToken, switchPackage, changedOption, processType) => {        
+const processParticipantLoginMethod = async (participantAuthenticationEmail, participantToken, participantUid, switchPackage, changedOption, processType) => {        
     if (processType === 'removeEmail' || processType === 'removePhone') {
         ({switchPackage, changedOption} = getLoginRemovalSwitchPackage(processType, participantAuthenticationEmail, participantUid));
     }
@@ -634,6 +636,7 @@ const processParticipantLoginMethod = async (participantAuthenticationEmail, par
             const url = `${baseAPI}/dashboard?api=updateUserAuthentication`;
             const signinMechanismPayload = { "data": switchPackage };
             
+            const bearerToken = await getAccessToken();
             const response = await postLoginData(url, signinMechanismPayload, bearerToken);
             const responseJSON = await response.json();
 
@@ -644,7 +647,7 @@ const processParticipantLoginMethod = async (participantAuthenticationEmail, par
                     showAuthUpdateAPIError('modalBody', "IMPORTANT: There was an error updating the participant's profile.\n\nPLEASE PROCESS THE OPERATION AGAIN.");
                     console.error('Failed to update participant Firestore profile');
                 } else {
-                    updateUIOnAuthResponse(switchPackage, changedOption, responseJSON, response.status, bearerToken);
+                    updateUIOnAuthResponse(switchPackage, changedOption, responseJSON, response.status);
                 }   
             }
         } catch (error) {
@@ -696,7 +699,7 @@ const postLoginData = async (url = '', data = {}, bearerToken) => {
     }
 }
 
-const updateUIOnAuthResponse = (switchPackage, changedOption, responseData, status, bearerToken) => {
+const updateUIOnAuthResponse = (switchPackage, changedOption, responseData, status) => {
     hideAnimation();
 
     if (status === 200) {
@@ -707,7 +710,7 @@ const updateUIOnAuthResponse = (switchPackage, changedOption, responseData, stat
             document.getElementById('Change Login Emailrow').children[1].innerHTML = 'Updating login data';
             document.getElementById('Change Login Phonerow').children[1].innerHTML = 'Updating login data';
         }
-        reloadParticipantData(changedOption.token, bearerToken);
+        reloadParticipantData(changedOption.token);
     } else {
         const errorMessage = responseData.error || 'Operation Unsuccessful!';
         showAuthUpdateAPIError('modalBody', errorMessage);
@@ -731,10 +734,10 @@ const showAuthUpdateAPIError = (bodyId, message) => {
     return false;
 }
 
-export const refreshParticipantAfterUpdate = async (participant, bearerToken) => {
+export const refreshParticipantAfterUpdate = async (participant) => {
     showAnimation();
     localStorage.setItem('participant', JSON.stringify(participant));
-    renderParticipantDetails(participant, {}, bearerToken);
+    renderParticipantDetails(participant, {});
     appState.setState({unsavedChangesTrack:{saveFlag: false, counter: 0}})
     let alertList = document.getElementById('alert_placeholder');
     let template = '';
@@ -1090,9 +1093,8 @@ const cleanPhoneNumber = (changedOption) => {
  * Else, alert the user that the update was unsuccessful.
  * @param {object} participant - the existing participant object 
  * @param {object} changedOption - the changed user data
- * @param {string} bearerToken - the site key to pass to the POST request 
  */
-export const submitClickHandler = async (participant, changedOption, bearerToken) => {
+export const submitClickHandler = async (participant, changedOption) => {
     const isParticipantVerified = participant[fieldMapping.verifiedFlag] == fieldMapping.verified;
     const adminEmail = appState.getState().userSession?.email ?? '';
     const submitButtons = document.getElementsByClassName('updateMemberData');
@@ -1105,7 +1107,7 @@ export const submitClickHandler = async (participant, changedOption, bearerToken
                 const isSuccess = processUserDataUpdate(changedUserDataForProfile, changedUserDataForHistory, participant[fieldMapping.userProfileHistory], participant.state.uid, adminEmail, isParticipantVerified);
                 if (isSuccess) {
                     const updatedParticipant = { ...participant, ...changedUserDataForProfile};
-                    await refreshParticipantAfterUpdate(updatedParticipant, bearerToken);
+                    await refreshParticipantAfterUpdate(updatedParticipant);
                 } else {
                     alert('Error: There was an error processing your changes. Please try again.');
                 }

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -92,7 +92,7 @@ export const getFieldValues = (variableValue, conceptId) => {
     }
 
     if (!variableValue) return '';
-    else if (conceptId === 'Change Login Email' && variableValue.startsWith('noReply')) return '';
+    else if (conceptId === 'Change Login Email' && variableValue.startsWith('noreply')) return '';
     else if (variableValue in fieldValues) return fieldValues[variableValue];
     else if (conceptId in phoneFieldValues) return phoneFieldValues[conceptId];
     else return variableValue;
@@ -458,7 +458,7 @@ export const attachUpdateLoginMethodListeners = (participantAuthenticationEmail,
                 email: participantAuthenticationEmail 
             };
             const inputFields = generateLoginFormInputFields(currentLogins, loginType);
-            const formButtons = generateAuthenticationFormButtons(!!(currentLogins.email && !currentLogins.email.startsWith('noReply')), !!currentLogins.phone, loginType);
+            const formButtons = generateAuthenticationFormButtons(!!(currentLogins.email && !currentLogins.email.startsWith('noreply')), !!currentLogins.phone, loginType);
             body.innerHTML = `
                 <div>
                     <form id="authDataForm" method="post">
@@ -502,7 +502,7 @@ export const attachUpdateLoginMethodListeners = (participantAuthenticationEmail,
 };
 
 const generateLoginFormInputFields = (currentLogins, loginType) => {
-    const currentEmailLogin = currentLogins.email && !currentLogins.email.startsWith('noReply') ? currentLogins.email : 'Not in use';
+    const currentEmailLogin = currentLogins.email && !currentLogins.email.startsWith('noreply') ? currentLogins.email : 'Not in use';
     const currentPhoneLogin = currentLogins.phone ? formatPhoneNumber(currentLogins.phone) : 'Not in use';
     
     const loginTypeConfig = {
@@ -591,7 +591,7 @@ const getLoginRemovalSwitchPackage = (processType, participantAuthenticationEmai
     const switchPackage = {};
     const changedOption = {};
     if (processType === 'removeEmail') {
-        const placeholderForEmailRemoval = `noReply${participantUid}@episphere.github.io`;
+        const placeholderForEmailRemoval = `noreply${participantUid}@episphere.github.io`;
         switchPackage['email'] = placeholderForEmailRemoval;
         switchPackage['flag'] = 'updateEmail';
         changedOption[fieldMapping.accountEmail] = placeholderForEmailRemoval;

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -1138,7 +1138,7 @@ const findChangedUserDataValues = (newUserData, existingUserData) => {
     newUserData = cleanPhoneNumber(newUserData);
     Object.keys(newUserData).forEach(key => {
       if (newUserData[key] !== existingUserData[key]) {
-        changedUserDataForProfile[key] = newUserData[key] ?? '';
+        changedUserDataForProfile[key] = newUserData[key];
         if (!excludeHistoryKeys.includes(key)) {
             changedUserDataForHistory[key] = existingUserData[key] ?? '';
         }
@@ -1175,7 +1175,7 @@ const findChangedUserDataValues = (newUserData, existingUserData) => {
         changedUserDataForHistory[fieldMapping.voicemailOther] = existingUserData[fieldMapping.voicemailOther] ?? fieldMapping.no;
     }
 
-return { changedUserDataForProfile, changedUserDataForHistory };
+    return { changedUserDataForProfile, changedUserDataForHistory };
 };
 
 /**
@@ -1193,6 +1193,10 @@ const processUserDataUpdate = async (changedUserDataForProfile, changedUserDataF
         if (isParticipantVerified) {
             changedUserDataForProfile[fieldMapping.userProfileHistory] = updateUserHistory(changedUserDataForHistory, userHistory, adminEmail);
         }
+        
+        if (changedUserDataForProfile[fieldMapping.fName]) changedUserDataForProfile['query.firstName'] = changedUserDataForProfile[fieldMapping.fName];
+        if (changedUserDataForProfile[fieldMapping.lName]) changedUserDataForProfile['query.lastName'] = changedUserDataForProfile[fieldMapping.lName];
+
         changedUserDataForProfile['uid'] = participantUid;
         await postUserDataUpdate(changedUserDataForProfile)
         .catch(function (error) {

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -1132,6 +1132,11 @@ export const submitClickHandler = async (participant, changedOption) => {
  * If a number is in the changedUserDataForProfile, the participant has added this phone number. Add it to the allPhoneNo field.
  * Then check the userData profile for an existing value at the field being updated. The participant is updating this phone number. Remove it from the allPhoneNo field.
  * If an empty string is in the changedUserDataForProfile, the participant has removed this phone number. Remove it from the allPhoneNo field.
+ * TODO: Topic for ongoing discussion:
+ *      Inside the forEach loop:
+ *              The first if statement checks if the phone number is in the changedUserDataForProfile. If it is, add it to the allPhoneNo field.
+ *              The second if statement checks if an existing phone number is in the current userData profile. If it is, that means the participant is updating the existing value in favor of the new value.
+ *                      Remove the existing value from the allPhoneNo field.
  */
 const handleAllPhoneNoField = (changedUserDataForProfile, participant) => {
     const allPhoneNo = participant.query.allPhoneNo ?? [];
@@ -1159,14 +1164,18 @@ const handleAllPhoneNoField = (changedUserDataForProfile, participant) => {
    * Handle the allEmails field in the user profile
    * If an email is in the changedUserDataForProfile, the participant has added this email. Add it to the allEmails field.
    * If an email is in the changedUserDataForHistory, the participant has removed this email. Remove it from the allEmails field.
+   * TODO: Topic for ongoing discussion:
+   *        Inside the forEach loop:
+   *            The first if statement checks if the email address is in the changedUserDataForProfile. If it is, add it to the allEmails field.
+   *            The second if statement checks if an existing email address is in the current userData profile. If it is, that means the participant is updating the existing value in favor of the new value.
+   *                    Remove the existing value from the allEmails field.
    */
   const handleAllEmailField = (changedUserDataForProfile, participant) => {
     const allEmails = participant.query.allEmails ?? [];
-    const emailTypes = [fieldMapping.prefEmail, fieldMapping.email1, fieldMapping.email2];
   
     emailTypes.forEach(emailType => {
       if (changedUserDataForProfile[emailType] && !allEmails.includes(changedUserDataForProfile[emailType])) {
-        allEmails.push(changedUserDataForProfile[emailType].toLowerCase());
+        allEmails.push(changedUserDataForProfile[emailType].trim()?.toLowerCase());
       }
   
       if (changedUserDataForProfile[emailType] || changedUserDataForProfile[emailType] === '') {
@@ -1260,8 +1269,8 @@ const processUserDataUpdate = async (changedUserDataForProfile, changedUserDataF
             changedUserDataForProfile[fieldMapping.userProfileHistory] = updateUserHistory(changedUserDataForHistory, userHistory, adminEmail);
         }
         
-        if (changedUserDataForProfile[fieldMapping.fName]) changedUserDataForProfile['query.firstName'] = changedUserDataForProfile[fieldMapping.fName].toLowerCase();
-        if (changedUserDataForProfile[fieldMapping.lName]) changedUserDataForProfile['query.lastName'] = changedUserDataForProfile[fieldMapping.lName].toLowerCase();
+        if (changedUserDataForProfile[fieldMapping.fName]) changedUserDataForProfile['query.firstName'] = changedUserDataForProfile[fieldMapping.fName].trim()?.toLowerCase();
+        if (changedUserDataForProfile[fieldMapping.lName]) changedUserDataForProfile['query.lastName'] = changedUserDataForProfile[fieldMapping.lName].trim()?.toLowerCase();
 
         changedUserDataForProfile['uid'] = participantUid;
         await postUserDataUpdate(changedUserDataForProfile)

--- a/siteManagerDashboard/participantHeader.js
+++ b/siteManagerDashboard/participantHeader.js
@@ -12,8 +12,7 @@ export const headerImportantColumns = [
     { field: 'Site' },
     { field: 'Year(s) in Connect' },
     { field: 'Participation Status'},
-   // { field: 'Enrollment Status'},
-     { field: 'Suspended Contact'}
+    { field: 'Suspended Contact'}
 ];
 
 
@@ -31,10 +30,6 @@ export const renderParticipantHeader = (participant) => {
         (headerImportantColumns[x].field === 'Participation Status' ) ?
             template += `<span><b>Participation Status </b></span> : ${getParticipantStatus(participant)}  &nbsp;`
         :
-
-        // (headerImportantColumns[x].field === 'Enrollment Status' ) ?
-        //     template += `<span><b>Enrollment Status </b></span> : ${getEnrollmentStatus(participant)}  &nbsp;`
-        // :
 
         (headerImportantColumns[x].field === 'Suspended Contact'  ) ?
             template += getParticipantSuspendedDate(participant)
@@ -85,7 +80,6 @@ export const renderParticipantHeader = (participant) => {
 } 
 
 // Year(s) in Connect : 1  
-
 const getYearsInConnect = (participant) => {
     let timeProfileSubmitted = participant[fieldMapping.timeProfileSubmitted];
     let submittedYear = String(timeProfileSubmitted);
@@ -97,18 +91,16 @@ const getYearsInConnect = (participant) => {
     let totalYears =  currentYear - submittedYear;
     totalYears <= 0 ? totalYears = '< 1' : totalYears;
     let yearsInConnect = totalYears;
-    return yearsInConnect;
+    return typeof(yearsInConnect) !== 'string' && isNaN(yearsInConnect) ? 'data deleted' : yearsInConnect;
 }
 
 
 
 const concatDOB = (participant) => {
-    const monthList = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
     const participantBirthMonth = participant[fieldMapping.birthMonth];
     const participantBirthDate = participant[fieldMapping.birthDay];
     const participantBirthYear = participant[fieldMapping.birthYear];
-    const dateofBirth = participantBirthMonth + '/' + participantBirthDate + '/' + participantBirthYear;
-    return dateofBirth; //  07/02/1966  
+    return participantBirthMonth && participantBirthDate && participantBirthYear ? participantBirthMonth + '/' + participantBirthDate + '/' + participantBirthYear : 'data deleted'; //  07/02/1966 or 'data deleted' 
 
 }
 
@@ -121,6 +113,7 @@ export const getParticipantStatus = (participant) => {
    if (typeof participant !== "string") {
         const statusValue = participant[fieldMapping.participationStatus];
         if (statusValue !== undefined && statusValue !== ``)  return fieldMapping[statusValue];
+        else if (participant[fieldMapping.dataDestroyCategorical] === fieldMapping.requestedDataDestroySigned) return 'data deleted';
         else return `No Refusal`;
     }
 }


### PR DESCRIPTION
This PR addresses multiple login options in SMDB.
It is a newly requested update to Abhinav's switch login mechanism [update #493](https://github.com/episphere/dashboard/issues/493) 

-Participant can have max 1 email and 1 phone auth method
-Only one method is required
-phone auth can only be removed if email auth exists
-email auth can only be removed if phone auth exists
-both firebase Auth and the participant’s firestore profiles are updated

Important workaround:
There is an issue where Firebase Auth doesn’t allow email removal.
The ops team wanted email removal to be an option for participants.
To work around this: on email removal request, we:
—update the participant `firebase auth email` to `noReply${uid}@episphere.github.io]`
—update the firestore participant’s `firestore profile` to the same
—filter emails starting with `noReply` and return an empty string with status=`Not in use` 
This effectively disables the participant’s prior email auth method and was approved/requested by the ops team.