### PR TITLE
SiteManager Dashaboard: Updated covid flag CID in Participant Summary

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -121,7 +121,7 @@ export default
     "lawCompletedDate1": 264644252,
     "lawStartDate1": 452942800,
 
-    "covidFlag": 793330426,
+    "covidFlag": 220186468,
     "covidStartDate": 268176409,
     "covidCompletedDate": 784810139,
 


### PR DESCRIPTION
This PR addresses following issue:
Wrong CID was entered in this [issue](https://github.com/episphere/dashboard/issues/528) & 
upon cross check came across correct COVID Flag CID: 220186468

**Required for upcoming Stage/Prod June release**

Related PR: https://github.com/episphere/dashboard/pull/539

PoC:
![Screenshot 2023-06-22 at 2 39 44 PM](https://github.com/episphere/dashboard/assets/30497847/0466cd95-2e35-446b-83e2-5afa34520d2f)
