### PR TITLE
expand name search & fix login-mechanism reporting

### DIFF
--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -814,7 +814,6 @@ const tableTemplate = (data, showButtons) => {
 }
 
 const addEventShowMoreInfo = (data) => {
-    console.log('addEventShowMoreInfo');
     const elements = document.getElementsByClassName('showMoreInfo');
     Array.from(elements).forEach(element => {
         element.addEventListener('click', () => {

--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -516,6 +516,8 @@ const tableTemplate = (data, showButtons) => {
                ( template += `<td>${participant[x] ? 'Text Message' : ''}</td>` )
             : (participant[x] && participant[x] === fieldMapping.prefEmail) ?
                ( template += `<td>${participant[x] ? 'Email' : ''}</td>` )
+            : (participant[x] && x === fieldMapping.accountEmail.toString()) ?
+                ( template += `<td>${participant[x].startsWith('noreply') ? '' : participant[x]}</td>` )
             : ((x === (fieldMapping.signinDate).toString()) || (x === (fieldMapping.userProfileDateTime).toString()) || (x === (fieldMapping.consentDate).toString())
              || (x === (fieldMapping.recruitmentDate).toString()) || (x === (fieldMapping.verficationDate).toString())) ? 
                ( template += `<td>${participant[x] ? new Date(participant[x]).toLocaleString() : ''}</td>`) // human readable time date
@@ -812,6 +814,7 @@ const tableTemplate = (data, showButtons) => {
 }
 
 const addEventShowMoreInfo = (data) => {
+    console.log('addEventShowMoreInfo');
     const elements = document.getElementsByClassName('showMoreInfo');
     Array.from(elements).forEach(element => {
         element.addEventListener('click', () => {

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -1131,8 +1131,8 @@ const cleanPhoneNumber = (changedOption) => {
 
 };
 
-const firstNameTypes = [fieldMapping.fName, fieldMapping.prefName, fieldMapping.consentFirstName];
-const lastNameTypes = [fieldMapping.lName, fieldMapping.consentLastName];
+const firstNameTypes = [fieldMapping.consentFirstName, fieldMapping.fName, fieldMapping.prefName];
+const lastNameTypes = [fieldMapping.consentLastName, fieldMapping.lName];
 const phoneTypes = [fieldMapping.cellPhone, fieldMapping.homePhone, fieldMapping.otherPhone];
 const emailTypes = [fieldMapping.prefEmail, fieldMapping.email1, fieldMapping.email2];
 
@@ -1207,7 +1207,6 @@ const handleNameField = (nameTypes, fieldName, changedUserDataForProfile, partic
 const handleAllPhoneNoField = (changedUserDataForProfile, participant) => {
     const allPhoneNo = participant.query.allPhoneNo ?? [];
     
-  
     phoneTypes.forEach(phoneType => {
       if (changedUserDataForProfile[phoneType] && !allPhoneNo.includes(changedUserDataForProfile[phoneType])) {
         allPhoneNo.push(changedUserDataForProfile[phoneType]);
@@ -1343,9 +1342,6 @@ const processUserDataUpdate = async (changedUserDataForProfile, changedUserDataF
         if (isParticipantVerified) {
             changedUserDataForProfile[fieldMapping.userProfileHistory] = updateUserHistory(changedUserDataForHistory, userHistory, adminEmail, changedUserDataForProfile[fieldMapping.suffix]);
         }
-        
-        // if (changedUserDataForProfile[fieldMapping.fName]) changedUserDataForProfile['query.firstName'] = changedUserDataForProfile[fieldMapping.fName].trim()?.toLowerCase();
-        // if (changedUserDataForProfile[fieldMapping.lName]) changedUserDataForProfile['query.lastName'] = changedUserDataForProfile[fieldMapping.lName].trim()?.toLowerCase();
 
         changedUserDataForProfile['uid'] = participantUid;
         await postUserDataUpdate(changedUserDataForProfile)

--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -1171,11 +1171,11 @@ export const submitClickHandler = async (participant, changedOption) => {
 };
 
 /**
- * Handle the query.frstName and query.lastName fields in the participant profile.
- * Check the changedUserDataForProfile object and then the participant profile for all name types. If a name is in changedUserDataForProfile, that's the up-to-date version. Add it to the queryNameArray.
- * If a nameType isn't in changedUserData, check the existing participant profile and add that to the queryNameArray.
+ * Handle the query.frstName and query.lastName fields.
+ * Check changedUserDataForProfile the participant profile for all name types. If a name is in changedUserDataForProfile, Add it to the queryNameArray.
+ * Else, check the existing participant profile and add that to the queryNameArray.
  * If a nameType is an empty string in changedUserData, don't add it to the queryNameArray even if it exists in the participant profile. The empty string means the participant wants the name removed.
- * Lastly, remove duplicates. This can happen when the participant has a consent name that matches the first or last name.
+ * Lastly, remove duplicates. This happens when consent name matches the first or last name.
  * @param {array} nameTypes - array of name types to check.
  * @param {string} fieldName - the name of the field to update.
  * @param {object} changedUserDataForProfile - the changed user data.
@@ -1203,11 +1203,6 @@ const handleNameField = (nameTypes, fieldName, changedUserDataForProfile, partic
  * If a number is in the changedUserDataForProfile, the participant has added this phone number. Add it to the allPhoneNo field.
  * Then check the userData profile for an existing value at the field being updated. The participant is updating this phone number. Remove it from the allPhoneNo field.
  * If an empty string is in the changedUserDataForProfile, the participant has removed this phone number. Remove it from the allPhoneNo field.
- * TODO: Topic for ongoing discussion:
- *      Inside the forEach loop:
- *              The first if statement checks if the phone number is in the changedUserDataForProfile. If it is, add it to the allPhoneNo field.
- *              The second if statement checks if an existing phone number is in the current userData profile. If it is, that means the participant is updating the existing value in favor of the new value.
- *                      Remove the existing value from the allPhoneNo field.
  */
 const handleAllPhoneNoField = (changedUserDataForProfile, participant) => {
     const allPhoneNo = participant.query.allPhoneNo ?? [];
@@ -1235,11 +1230,6 @@ const handleAllPhoneNoField = (changedUserDataForProfile, participant) => {
    * Handle the allEmails field in the user profile
    * If an email is in the changedUserDataForProfile, the participant has added this email. Add it to the allEmails field.
    * If an email is in the changedUserDataForHistory, the participant has removed this email. Remove it from the allEmails field.
-   * TODO: Topic for ongoing discussion:
-   *        Inside the forEach loop:
-   *            The first if statement checks if the email address is in the changedUserDataForProfile. If it is, add it to the allEmails field.
-   *            The second if statement checks if an existing email address is in the current userData profile. If it is, that means the participant is updating the existing value in favor of the new value.
-   *                    Remove the existing value from the allEmails field.
    */
   const handleAllEmailField = (changedUserDataForProfile, participant) => {
     const allEmails = participant.query.allEmails ?? [];
@@ -1264,21 +1254,16 @@ const handleAllPhoneNoField = (changedUserDataForProfile, participant) => {
 
   /**
  * Iterate the new values, compare them to existing values, and return the changed values.
- * write an empty string to firestore if the history value is null/undefined/empty --per spec on 05-09-2023
- * write an empty string to firestore if the profile value is null/undefined/empty --per spec on 05-09-2023
+ * write an empty string to firestore if the history value is null/undefined/empty
+ * write an empty string to firestore if the profile value is null/undefined/empty 
  * @param {object} newUserData - the newly entered form fields
  * @param {object} existingUserData - the existing user profile data
  * @returns {changedUserDataForProfile, changedUserDataForHistory} - parallel objects containing the changed values
  * Contact information requires special handling because of the preference selectors
  *   if the user is changing their cell phone number, we need to update the canWeVoicemailMobile and canWeText values
  *   the same is true for homePhone and otherPhone (canWeVoicemailHome and canWeVoicemailOther)
- *   if user deletes a number, set canWeVoicemail and canWeText to '' (empty string) --per spec on 05-09-2023
+ *   if user deletes a number, set canWeVoicemail and canWeText to '' (empty string)
  *   if user updates a number, ensure the canWeVoicemail and canWeText values are set. Use previous values as fallback.
- *   Update: 05-26-2023 do not include email addresses in user profile archiving. Exclude those keys from the history object
- *   Update: 06-27-2023
- *     (1) Do not tie empty text and voicemail permissions to profile history.
- *     (2) Use cId.noneOfTheseApply for suffix that had a value and now has no value
- *     (3) Default phone permissions to cId.no instead of using an empty string.
 */
 const findChangedUserDataValues = (newUserData, existingUserData) => {
     const changedUserDataForProfile = {};

--- a/siteManagerDashboard/participantLookup.js
+++ b/siteManagerDashboard/participantLookup.js
@@ -137,8 +137,8 @@ const addEventSearch = () => {
     form.addEventListener('submit', e => {
         document.getElementById("search-failed").hidden = true;
         e.preventDefault();
-        const firstName = document.getElementById('firstName').value;
-        const lastName = document.getElementById('lastName').value;
+        const firstName = document.getElementById('firstName').value?.toLowerCase();
+        const lastName = document.getElementById('lastName').value?.toLowerCase();
         const dob = document.getElementById('dob').value;
         const email = document.getElementById('email').value;
         const phone = document.getElementById('phone').value;
@@ -227,6 +227,7 @@ export const showNotifications = (data, error) => {
 
 
 export const findParticipant = async (query) => {
+    console.log('query', `${baseAPI}/dashboard?api=getParticipants&type=filter&${query}`)
     const siteKey = await getAccessToken();
     const response = await fetch(`${baseAPI}/dashboard?api=getParticipants&type=filter&${query}`, {
         method: "GET",

--- a/siteManagerDashboard/participantLookup.js
+++ b/siteManagerDashboard/participantLookup.js
@@ -1,5 +1,5 @@
-import { renderNavBarLinks, dashboardNavBarLinks, renderLogin, removeActiveClass } from './navigationBar.js';
-import { renderTable, filterdata, filterBySiteKey, renderData, importantColumns, addEventFilterData, activeColumns } from './participantCommons.js';
+import { dashboardNavBarLinks, removeActiveClass } from './navigationBar.js';
+import { renderTable, filterdata, filterBySiteKey, renderData, addEventFilterData, activeColumns } from './participantCommons.js';
 import { internalNavigatorHandler, getDataAttributes, getAccessToken, showAnimation, hideAnimation, baseAPI, urls } from './utils.js';
 import { nameToKeyObj } from './siteKeysToName.js';
 


### PR DESCRIPTION
This PR is in support of:
https://github.com/episphere/connect/issues/654
And
https://github.com/episphere/dashboard/pull/538


Re: Expand name search:
•Write updates to `query.firstName` and `query.lastName` fields as arrays.
`query.firstName` field includes: consent first name (471168198), first name (399159511), and preferred name (153211406).
`query.lastName` field includes: consent last name (736251808) and last name(996038075).

Re: Multi-logins:
•Fix handling of `phone`, `password`, and `passwordAndPhone` sign-in mechanism reporting (995036844). The issue was: ‘noreply’ emails were not factored into the reporting functionality, so removed emails were causing incorrect reporting of sign-in mechanism.

•Hide ‘noreply’ account emails in the participant lookup results. I am now aware that this field exists in results and the results are hidden when accountEmail starts with ‘noreply’. Screenshots (before and after) are included.

Before:
<img width="1529" alt="before noreply filter" src="https://github.com/episphere/dashboard/assets/93854858/70f4d0ae-3e55-4f61-b21f-0038e2a2e0ce">

After:
<img width="1530" alt="after noreply filter" src="https://github.com/episphere/dashboard/assets/93854858/6de45019-865d-4fad-941f-62c52d2c0944">
