### PR TITLE
error fix: update dob handling

### DIFF
--- a/siteManagerDashboard/participantDetailsHelpers.js
+++ b/siteManagerDashboard/participantDetailsHelpers.js
@@ -795,7 +795,7 @@ export const saveResponses = (participant, changedOption, editedElement, concept
                     const year = changedOption[fieldMapping.birthYear] || participant[fieldMapping.birthYear];
                     const dateOfBirthComplete = fieldMapping.dateOfBirthComplete;
                     conceptIdArray.push(dateOfBirthComplete);
-                    changedOption[currentConceptId] =  year + month.padStart(2, '0')+ day.padStart(2, '0') ;
+                    changedOption[fieldMapping.dateOfBirthComplete] =  year + month.padStart(2, '0')+ day.padStart(2, '0');
                 }
 
                 updateUIValues(editedElement, newValueElement.value, conceptIdArray);


### PR DESCRIPTION
Update to https://github.com/episphere/dashboard/pull/531

Fix error in dob handling. A bad reference was causing dob to be written incorrectly when 2 or more dob fields were updated.

The fix: make the dateOfBirthComplete write explicit.