### PR TITLE
remove console.log() query string

### DIFF
--- a/siteManagerDashboard/participantLookup.js
+++ b/siteManagerDashboard/participantLookup.js
@@ -227,7 +227,6 @@ export const showNotifications = (data, error) => {
 
 
 export const findParticipant = async (query) => {
-    console.log('query', `${baseAPI}/dashboard?api=getParticipants&type=filter&${query}`)
     const siteKey = await getAccessToken();
     const response = await fetch(`${baseAPI}/dashboard?api=getParticipants&type=filter&${query}`, {
         method: "GET",


### PR DESCRIPTION
Supporting: https://github.com/episphere/connect/issues/654 - expanded name search.
Remove a console.log() statement I missed - logging a query string during search