### PR TITLE
SiteManager Dashboard: Added new variables under campaign types

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -448,6 +448,8 @@ export default
     'lowIncomeAreas': 663706936,
     'studyIdTimeStamp': 521025370,
     'automatedVerification': 444699761,
+    'researchRegistry': 208952854,
+    'popUp': 296312382,
     'outreachRequiredForVerification': 188797763,
     'manualVerification': 953614051,
     'duplicateType': 148197146,

--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -702,9 +702,13 @@ const tableTemplate = (data, showButtons) => {
                         template += `<td>${participant['state'][fieldMapping.campaignType.toString()] ? `Technology Adapters` : ``}</td>`
                     :  ( participant['state'][fieldMapping.campaignType.toString()] === fieldMapping.lowIncomeAreas ) ?
                         template += `<td>${participant['state'][fieldMapping.campaignType.toString()] ? `Low Income Areas/Health Professional Shortage Areas` : ``}</td>`
+                    :  ( participant['state'][fieldMapping.campaignType.toString()] === fieldMapping.researchRegistry ) ?
+                    template += `<td>${participant['state'][fieldMapping.campaignType.toString()] ? `Research Registry` : ``}</td>`
+                    :  ( participant['state'][fieldMapping.campaignType.toString()] === fieldMapping.popUp ) ?
+                    template += `<td>${participant['state'][fieldMapping.campaignType.toString()] ? `Pop up` : ``}</td>`
                     :  ( participant['state'][fieldMapping.campaignType.toString()] === fieldMapping.noneOftheAbove ) ?
                         template += `<td>${participant['state'][fieldMapping.campaignType.toString()] ? `None of the Above` : ``}</td>`
-                    :
+                :
                         template += `<td>${participant['state'][fieldMapping.campaignType.toString()] ? `Other` : ``}</td>`)
                     )
             : (x === (fieldMapping.enrollmentStatus).toString()) ? 


### PR DESCRIPTION
Title^^
This PR addresses following issue:
https://github.com/episphere/connect/issues/669

PoC: (Test Participants & doesn't exist)
Research Registry:
<img width="1783" alt="Screenshot 2023-08-24 at 12 06 48 PM" src="https://github.com/episphere/dashboard/assets/30497847/4d143f73-0815-4c12-b097-0add78a68dea">

Pop Up:
<img width="1792" alt="Screenshot 2023-08-24 at 12 07 48 PM" src="https://github.com/episphere/dashboard/assets/30497847/dece1927-1e02-49b6-8c59-0936a2019d99">
