### PR TITLE
Updates for home mouthwash

### DIFF
--- a/siteManagerDashboard/assets/css/dashboard.css
+++ b/siteManagerDashboard/assets/css/dashboard.css
@@ -222,7 +222,6 @@ table {
 }
 
 .sticky-header {
-    height: 600px; 
     overflow-y: auto; 
     position: sticky; 
     top: 0;

--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -504,5 +504,21 @@ export default
     959657954 : 'Verification Complete',
     850536553 : 'Cannot Be Verified' ,
 	364179400 : 'Verified - mimimally Enrolled',
-    485892221 : 'Fully Enrolled'   
-}
+    485892221 : 'Fully Enrolled',
+
+    collectionDetails: 173836415,
+    baseline: 266600170,
+    bioKitMouthwash: 8583443674,
+    kitType: 379252329,
+    kitTypeValues: {
+        mouthwash: 390351864
+    },
+    kitStatus: 221592017,
+    kitStatusValues: {
+        pending: 517216441,
+        addressPrinted: 849527480,
+        assigned: 241974920,
+        shipped: 277438316,
+        recieved: 375535639
+    },
+};

--- a/siteManagerDashboard/index.html
+++ b/siteManagerDashboard/index.html
@@ -77,10 +77,8 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" defer></script>
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" defer></script>
         <script src="https://cdn.plot.ly/plotly-latest.min.js" defer></script>
-        <script src="https://cdn.jsdelivr.net/npm/pdf-lib/dist/pdf-lib.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/pdf-lib/dist/pdf-lib.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/downloadjs/1.4.8/download.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/downloadjs/1.4.8/download.js"></script>
         <script src="https://www.gstatic.com/firebasejs/7.14.2/firebase-app.js"></script>
         <script src="https://www.gstatic.com/firebasejs/7.14.2/firebase-auth.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/pikaday/pikaday.js"></script>

--- a/siteManagerDashboard/index.js
+++ b/siteManagerDashboard/index.js
@@ -567,7 +567,7 @@ const filterModuleMetrics = (allModulesMetrics, moduleOneMetrics, modulesTwoThre
     });
     moduleOneMetrics && moduleOneMetrics.forEach((data) => moduleOne += data.countModule1);
     modulesTwoThreeMetrics && modulesTwoThreeMetrics.forEach((data) =>  modulesTwoThree += data.countModules);
-    moduleNoneMetrics && moduleNoneMetrics.filter((data) =>  noModules += data.countModules);
+    moduleNoneMetrics && moduleNoneMetrics.forEach((data) =>  noModules += data.countModules);
 
     return {
         noModulesSubmitted: noModules,

--- a/siteManagerDashboard/index.js
+++ b/siteManagerDashboard/index.js
@@ -282,7 +282,6 @@ const transformDataForCharts = (siteData) => {
     allModules: allModulesMetrics,
     moduleOne: moduleOneMetrics,
     modulesTwoThree: modulesTwoThreeMetrics,
-    allModulesAllSamples: allModulesAllSamplesMetrics,
     modulesNone: modulesNoneMetrics,
     ssn: ssnMetrics,
     biospecimen: biospecimenMetrics,
@@ -317,8 +316,7 @@ const transformDataForCharts = (siteData) => {
     modulesTwoThreeMetrics,
     modulesNoneMetrics,
     activeVerificationStatus.verified,
-    passiveVerificationStatus.verified,
-    allModulesAllSamplesMetrics
+    passiveVerificationStatus.verified
   );
   const ssnStats = filterSsnMetrics(ssnMetrics, activeVerificationStatus.verified, passiveVerificationStatus.verified);
   const biospecimenStats = filterBiospecimenStats(
@@ -554,31 +552,33 @@ const filterOptOutsMetrics = (participantOptOutsMetric) => {
     return currentWorflowObj;
 }
 
-const filterModuleMetrics = (participantsModuleMetrics, participantModuleOne, participantModulesTwoThree, participantModuleNone, activeVerifiedParticipants, passiveVerifiedParticipants, participantsAllModulesAllSamples) => {
-    let currentWorflowObj = {}
-    let noModulesSubmitted = 0
-    let moduleOneSubmitted = 0
-    let modulesTwoThreeSubmitted = 0
-    let modulesSubmitted = 0
+const filterModuleMetrics = (allModulesMetrics, moduleOneMetrics, modulesTwoThreeMetrics, moduleNoneMetrics, activeVerifiedParticipants, passiveVerifiedParticipants) => {
+    let noModules = 0;
+    let moduleOne = 0;
+    let modulesTwoThree = 0;
+    let allModules = 0;
+    let allModulesBlood = 0;
     let allModulesAllSamples = 0;
   
-    participantsModuleMetrics && participantsModuleMetrics.filter(i => modulesSubmitted += i.countModules)
-    participantModuleOne && participantModuleOne.filter( i => moduleOneSubmitted += i.countModule1)
-    participantModulesTwoThree && participantModulesTwoThree.filter( i =>  modulesTwoThreeSubmitted += i.countModules )
-    participantModuleNone && participantModuleNone.filter( i =>  noModulesSubmitted += i.countModules )
-    participantsAllModulesAllSamples && participantsAllModulesAllSamples.forEach(item => {
-        allModulesAllSamples += item.countAllModulesAllSamples;
-    })
-    const verifiedParticipants = activeVerifiedParticipants + passiveVerifiedParticipants
-    currentWorflowObj.noModulesSubmitted = noModulesSubmitted
-    currentWorflowObj.moduleOneSubmitted = moduleOneSubmitted
-    currentWorflowObj.modulesTwoThreeSubmitted = modulesTwoThreeSubmitted
-    currentWorflowObj.modulesSubmitted = modulesSubmitted
-    currentWorflowObj.verifiedParticipants = verifiedParticipants
-    currentWorflowObj.allModulesAllSamples = allModulesAllSamples;
-    return currentWorflowObj;  
+    allModulesMetrics && allModulesMetrics.forEach((data) => {
+        allModules += data.countAllModules;
+        allModulesBlood += data.countAllModulesBlood;
+        allModulesAllSamples += data.countAllModulesBloodUrineMouthwash;
+    });
+    moduleOneMetrics && moduleOneMetrics.forEach((data) => moduleOne += data.countModule1);
+    modulesTwoThreeMetrics && modulesTwoThreeMetrics.forEach((data) =>  modulesTwoThree += data.countModules);
+    moduleNoneMetrics && moduleNoneMetrics.filter((data) =>  noModules += data.countModules);
 
-}
+    return {
+        noModulesSubmitted: noModules,
+        moduleOneSubmitted: moduleOne,
+        modulesTwoThreeSubmitted: modulesTwoThree,
+        modulesSubmitted: allModules,
+        verifiedParticipants: activeVerifiedParticipants + passiveVerifiedParticipants,
+        allModulesBlood,
+        allModulesAllSamples
+    };
+};
 
 const filterSsnMetrics = (participantsSsnMetrics, activeVerifiedParticipants, passiveVerifiedParticipants) => {
     let currentWorflowObj = {}

--- a/siteManagerDashboard/participantChartsRender.js
+++ b/siteManagerDashboard/participantChartsRender.js
@@ -74,7 +74,7 @@ export const renderAllCharts = (inputData) => {
       activeRecruits: recruitsCount.activeCount,
       passiveRecruits: recruitsCount.passiveCount,
       verifiedParticipants: activeVerificationStatus.verified + passiveVerificationStatus.verified,
-      modulesAndBaselinesCompletedParticipants: modulesStats.allModulesAllSamples,
+      allModulesBlood: modulesStats.allModulesBlood,
     });
     mainContent.appendChild(metricsCards);
 
@@ -99,8 +99,7 @@ export const renderAllCharts = (inputData) => {
    renderBiospecimenChart(biospecimenStats, ssnStats.verifiedParticipants, 'biospecimenMetrics');
 }
 
-// Add metrics cards at top of dashboard
-const metricsCardsView = ({activeRecruits, passiveRecruits, verifiedParticipants, modulesAndBaselinesCompletedParticipants}) => {
+const metricsCardsView = ({activeRecruits, passiveRecruits, verifiedParticipants, allModulesBlood}) => {
     const template = `
     <div class="metrics-card">
       <div class="card-top"></div>
@@ -116,20 +115,20 @@ const metricsCardsView = ({activeRecruits, passiveRecruits, verifiedParticipants
       <p class="ratio-value">
       <span class="hovertext" data-hover="out of Active and Passive Recruits">      
           Response Ratio:</span>
-          ${activeRecruits + passiveRecruits === 0 || verifiedParticipants ===0 ? 0 : (verifiedParticipants / (activeRecruits + passiveRecruits) * 100).toFixed(1)}%
+          ${activeRecruits + passiveRecruits === 0 || verifiedParticipants === 0 ? 0 : `${(verifiedParticipants / (activeRecruits + passiveRecruits) * 100).toFixed(1)}%`}
       </p>
     </div>
     <div class="metrics-card">
       <div class="card-top"></div>
-      <div class="metrics-value"> ${modulesAndBaselinesCompletedParticipants} </div>
-        <p class="metrics-value-description"><span class="hovertext" data-hover="All 4 Initial Survey Sections + All 3 Specimen Collections">Verified Participants who Completed Baseline Survey and Samples</span></p>
-        <p class="ratio-value">Completion Ratio: ${verifiedParticipants ===0 || modulesAndBaselinesCompletedParticipants ===0 ? 0 : (modulesAndBaselinesCompletedParticipants/verifiedParticipants*100).toFixed(1)}%</p>
-    </div>`
+      <div class="metrics-value">${allModulesBlood}</div>
+        <p class="metrics-value-description"><span class="hovertext" data-hover="All 4 Initial Survey Sections + Blood Collection">Verified Participants who Completed Baseline Survey and Blood Sample</span></p>
+        <p class="ratio-value">Completion Ratio: ${verifiedParticipants === 0 || allModulesBlood === 0 ? 0 : `${(allModulesBlood / verifiedParticipants * 100).toFixed(1)}%`}</p>
+    </div>`;
     const rowDiv = document.createElement("div");
     rowDiv.className = "row d-flex justify-content-center";
     rowDiv.innerHTML = template;
     return rowDiv;
- }
+ };
 
 const renderLabel = (count, recruitType) => {
     let template = ``;

--- a/siteManagerDashboard/participantSummary.js
+++ b/siteManagerDashboard/participantSummary.js
@@ -6,13 +6,6 @@ import { userProfile, verificationStatus, baselineBOHSurvey, baselineMRESurvey,b
     baselineMouthwashSample, baselineBloodUrineSurvey, baselineMouthwashSurvey, baselineEMR, baselinePayment } from './participantSummaryRow.js';
 import { humanReadableMDY, getCurrentTimeStamp, conceptToSiteMapping, pdfCoordinatesMap } from './utils.js';
 
-const headerImportantColumns = [
-    { field: fieldMapping.fName },
-    { field: fieldMapping.mName },
-    { field: fieldMapping.lName },
-    { field: fieldMapping.suffix }
-];
-
 const { PDFDocument, StandardFonts } = PDFLib
 
 document.body.scrollTop = document.documentElement.scrollTop = 0;
@@ -29,36 +22,36 @@ export const renderParticipantSummary = (participant) => {
 }
 
 export const render = (participant) => {
-    let template = `<div class="container-fluid">`
     if (!participant) {
-        template +=` 
-            <div id="root">
-            Please select a participant first!
-            </div>
-        </div>
-         `
-    } else {
-        template += `
-                <div id="root root-margin"> `
-        template += renderParticipantHeader(participant);
-        template += `<div class="table-responsive">
-                        <span> <h4 style="text-align: center;">Participant Summary </h4> </span>
-                        <div class="sticky-header">
-                            <table class="table table-striped">
-                                <thead class="thead-dark sticky-row"> 
-                                    <tr>
-                                        <th class="sticky-row" scope="col">Icon</th>
-                                        <th class="sticky-row" scope="col">Timeline</th>
-                                        <th class="sticky-row" scope="col">Category</th>
-                                        <th class="sticky-row" scope="col">Item</th>
-                                        <th class="sticky-row" scope="col">Status</th>
-                                        <th class="sticky-row" scope="col">Date</th>
-                                        <th class="sticky-row" scope="col">Setting</th>
-                                        <th class="sticky-row" scope="col">Refused</th>
-                                        <th class="sticky-row" scope="col">Extra</th>
-                                    </tr>
-                                </thead>   
-                            
+        return `
+            <div class="container-fluid">
+                <div id="root">
+                    Please select a participant first!
+                </div>
+            </div>`;
+    }
+
+    return `
+        <div class="container-fluid">
+            <div id="root root-margin">
+                ${renderParticipantHeader(participant)}
+                <div class="table-responsive">
+                    <span> <h4 style="text-align: center;">Participant Summary </h4> </span>
+                    <div class="sticky-header">
+                        <table class="table table-striped">
+                            <thead class="thead-dark sticky-row"> 
+                                <tr>
+                                    <th class="sticky-row" scope="col">Icon</th>
+                                    <th class="sticky-row" scope="col">Timeline</th>
+                                    <th class="sticky-row" scope="col">Category</th>
+                                    <th class="sticky-row" scope="col">Item</th>
+                                    <th class="sticky-row" scope="col">Status</th>
+                                    <th class="sticky-row" scope="col">Date</th>
+                                    <th class="sticky-row" scope="col">Setting</th>
+                                    <th class="sticky-row" scope="col">Refused</th>
+                                    <th class="sticky-row" scope="col">Extra</th>
+                                </tr>
+                            </thead>   
                             <tbody>
                                 <tr class="row-color-enrollment-dark">
                                     ${consentHandler(participant)}
@@ -89,7 +82,7 @@ export const render = (participant) => {
                                 </tr>
                                 <tr class="row-color-survey-light">
                                     ${baselineCOVIDSurvey(participant)}
-                                 </tr>
+                                </tr>
                                 <tr class="row-color-survey-dark">
                                     ${baselineBiospecSurvey(participant)}
                                 </tr>
@@ -122,16 +115,12 @@ export const render = (participant) => {
                                 ${participant[fieldMapping.destroyData] === fieldMapping.yes ? 
                                     (`<tr class="row-color-enrollment-dark"> ${dataDestroy(participant)} </tr>`): (``)}
                             </tbody>
-                            </table>
-                        </div>
-                    </div>`                
-        template +=`</div></div>`
-
-    }
-    return template;
-
-
-}
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>`;
+};
 
 const downloadCopyHandler = (participant) => {
     const a = document.getElementById('downloadCopy');

--- a/siteManagerDashboard/participantSummaryRow.js
+++ b/siteManagerDashboard/participantSummaryRow.js
@@ -87,12 +87,23 @@ export const baselineUrineSample = (participantModule) => {
     return template;
 }
 
+const kitStatusCidToString = {
+    517216441: "Pending",
+    849527480: "Address Printed",
+    241974920: "Assigned",
+    277438316: "Shipped",
+    375535639: "Received"
+};
+
 export const baselineMouthwashSample = (participantModule) => {
-    const isDataDestroyed = participantModule[fieldMapping.dataHasBeenDestroyed]
+    const isDataDestroyed = participantModule[fieldMapping.dataHasBeenDestroyed];
+    const isHomeMouthwashTubeReceived = participantModule[fieldMapping.collectionDetails]?.[fieldMapping.baseline]?.[fieldMapping.bioKitMouthwash]?.[fieldMapping.kitStatus] === fieldMapping.kitStatusValues.recieved;
     let template = ``;
     let refusedMouthwashOption = participantModule[fieldMapping.refusalOptions]?.[fieldMapping.refusedMouthwash];
     let mouthwashFlag = participantModule[fieldMapping.mouthwash];
-    
+    let kitStatusStr = kitStatusCidToString[participantModule[fieldMapping.collectionDetails]?.[fieldMapping.baseline]?.[fieldMapping.bioKitMouthwash]?.[fieldMapping.kitStatus]];
+    kitStatusStr = kitStatusStr ? "Kit " + kitStatusStr : "N/A";
+
     if (isDataDestroyed === fieldMapping.yes) {
         template += getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Sample", "Mouthwash", "Data Destroyed", "N/A", "N/A", "N", "N/A");
     } else if (refusedMouthwashOption === fieldMapping.yes) {
@@ -103,12 +114,16 @@ export const baselineMouthwashSample = (participantModule) => {
         template += getTemplateRow("fa fa-check fa-2x", "color: green", "Baseline", "Sample", "Mouthwash", "Collected", 
         humanReadableMDY(participantModule[fieldMapping.biospecimenCollectionDetail]?.[fieldMapping.biospecimenFollowUp]?.[fieldMapping.mouthwashDateTime]), 
         "Research", "N", "N/A");
+    } else if (isHomeMouthwashTubeReceived) {
+        template += getTemplateRow("fa fa-check fa-2x", "color: green", "Baseline", "Sample", "Mouthwash", "Collected", 
+        humanReadableMDY(participantModule[fieldMapping.biospecimenCollectionDetail]?.[fieldMapping.biospecimenFollowUp]?.[fieldMapping.mouthwashDateTime]), 
+        "Home", "N", kitStatusStr);
     } else {
-        template += getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Sample", "Mouthwash", "Not Collected", "N/A", "N/A", "N", "N/A");
+        template += getTemplateRow("fa fa-times fa-2x", "color: red", "Baseline", "Sample", "Mouthwash", "Not Collected", "N/A", "N/A", "N", kitStatusStr);
     }
     
     return template;
-}
+};
 
 export const baselineBOHSurvey = (participant) => {
     const isDataDestroyed = participant[fieldMapping.dataHasBeenDestroyed]
@@ -296,7 +311,7 @@ export const baselineBloodUrineSurvey = (participant) => {
 }
 
 export const baselineMouthwashSurvey = (participantModule) => {
-    const isDataDestroyed = participantModule[fieldMapping.dataHasBeenDestroyed]
+    const isDataDestroyed = participantModule[fieldMapping.dataHasBeenDestroyed];
     let refusedSpecimenOption = participantModule[fieldMapping.refusalOptions] && participantModule[fieldMapping.refusalOptions][fieldMapping.refusedSpecimenSurevys];
     let template = ``;
     
@@ -317,7 +332,7 @@ export const baselineMouthwashSurvey = (participantModule) => {
     }
 
     return template;
-}
+};
 
 export const baselineMenstrualSurvey = (participant) => {
     const isDataDestroyed = participant[fieldMapping.dataHasBeenDestroyed]


### PR DESCRIPTION
This PR implements updates requested in [#747](https://github.com/episphere/connect/issues/747). Below are details:
- Updated count in top right corner card, and also texts
- Updated counts in bottom right plot
- Implemented suggested changes in "Baseline/Survey/Home Mouthwash" and "Baseline/Sample/MouthWash" rows
- Full screen table display in 'Participant Summary' tab
- Code cleanup for clarity

Besides updates in current SMDB repo, scheduled queries (`participants_allModules`, `participants_biospecimen`) generating tables for metrics were also updated