### PR TITLE
SiteManager Dashboard: Missing labels in Participants table header

### DIFF
--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -471,16 +471,14 @@ const pagninationPreviousTrigger = () => {
 
 // TODO: needs code refactoring
 const tableTemplate = (data, showButtons) => {
-    let headerStringArray = [];
-    for (const column of importantColumns) {
-        let columnName = column;
-        const conceptIdMapping = JSON.parse(localStorage.getItem('conceptIdMapping'));
-        if (conceptIdMapping[column]) {
-            const customVariableName = getCustomVariableNames(column);
-            columnName = customVariableName || conceptIdMapping[column]["Variable Label"] || conceptIdMapping[column]["Variable Name"];
-        }
-        headerStringArray.push(`<th class="sticky-row">${columnName}</th>`);
-    }
+    const conceptIdMapping = JSON.parse(localStorage.getItem('conceptIdMapping'));
+    const headerStringArray = importantColumns.map(column => {
+        let columnName = conceptIdMapping[column]
+            ? getCustomVariableNames(column) || conceptIdMapping[column]["Variable Label"] || conceptIdMapping[column]["Variable Name"]
+            : column;
+    
+        return `<th class="sticky-row">${columnName}</th>`;
+    });
 
     let template = `<thead class="thead-dark sticky-row">
             <tr>


### PR DESCRIPTION
This PR addresses following issue:
https://github.com/episphere/connect/issues/839

This PR commit has caused the labels to disappear https://github.com/episphere/dashboard/commit/07dd2aa332650d917c0359586a6683b934ac6165#diff-7ea15755b96f81e101cab79407dda197fcc212e49fa4406c0abe35bbb459082a

- Fixed code & reduced duplication
- Added optional chaining for participants with missing refusal options [issue](https://github.com/episphere/connect/issues/839#issuecomment-1842026085)