### PR TITLE
SiteManger Dahboard: Add new age ranges for participants

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -185,13 +185,13 @@ export default
     "refusedBaselinePaymentDate": 438636757,
 
     // de-identified age
-    "ageRange1": 124276120,
-    "ageRange2": 450985724,
-    "ageRange3": 363147933,
-    "ageRange4": 636706443,
-    "ageRange5": 771230670,
-    "ageRange6": 713781738,
-    "ageRange7": 631272782,
+    "ageRange1": 713781738,
+    "ageRange2": 631272782,
+    "ageRange3": 124276120,
+    "ageRange4": 450985724,
+    "ageRange5": 363147933,
+    "ageRange6": 636706443,
+    "ageRange7": 771230670,
     "ageRange8": 722846087,
 
     // de-identified

--- a/siteManagerDashboard/index.js
+++ b/siteManagerDashboard/index.js
@@ -522,22 +522,31 @@ const filterRaceMetrics = (participantsRaceMetrics, activeVerifiedParticipants, 
 
 const filterAgeMetrics = (participantsAgeMetrics, activeVerifiedParticipants, passiveVerifiedParticipants) => {
     const verifiedParticipants =  activeVerifiedParticipants + passiveVerifiedParticipants
-    let ageObject = { '40-45': 0, '46-50': 0, '51-55': 0, '56-60': 0, '61-65': 0, verifiedParticipants: 0 }
+    let ageObject = { '30-34': 0, '35-39': 0, '40-45': 0, '46-50': 0, '51-55': 0, '56-60': 0, '61-65': 0, '66-70': 0, verifiedParticipants: 0 }
     participantsAgeMetrics && participantsAgeMetrics.forEach(i => {
         if (parseInt(i.recruitmentAge) === fieldMapping.ageRange1) {
-            ageObject['40-45'] +=  parseInt(i.recruitmentAgeCount)
+            ageObject['30-34'] +=  parseInt(i.recruitmentAgeCount)
         }
         else if (parseInt(i.recruitmentAge) === fieldMapping.ageRange2) {
-            ageObject['46-50'] +=  parseInt(i.recruitmentAgeCount)
+            ageObject['35-39'] +=  parseInt(i.recruitmentAgeCount)
         }
         else if (parseInt(i.recruitmentAge) === fieldMapping.ageRange3) {
-            ageObject['51-55'] +=  parseInt(i.recruitmentAgeCount)
+            ageObject['40-45'] +=  parseInt(i.recruitmentAgeCount)
         }
         else if (parseInt(i.recruitmentAge) === fieldMapping.ageRange4) {
-            ageObject['56-60'] +=  parseInt(i.recruitmentAgeCount)
+            ageObject['46-50'] +=  parseInt(i.recruitmentAgeCount)
         }
         else if (parseInt(i.recruitmentAge) === fieldMapping.ageRange5) {
+            ageObject['51-55'] +=  parseInt(i.recruitmentAgeCount)
+        }
+        else if (parseInt(i.recruitmentAge) === fieldMapping.ageRange6) {
+            ageObject['56-60'] +=  parseInt(i.recruitmentAgeCount)
+        }
+        else if (parseInt(i.recruitmentAge) === fieldMapping.ageRange7) {
             ageObject['61-65'] +=  parseInt(i.recruitmentAgeCount)
+        }
+        else if (parseInt(i.recruitmentAge) === fieldMapping.ageRange8) {
+            ageObject['66-70'] +=  parseInt(i.recruitmentAgeCount)
         }
     })
     ageObject.verifiedParticipants = verifiedParticipants

--- a/siteManagerDashboard/participantChartsRender.js
+++ b/siteManagerDashboard/participantChartsRender.js
@@ -332,25 +332,35 @@ const renderTotalCurrentWorkflow = (totalCurrentWorkflow, id) => {
 const renderAgeMetrics = (ageMetrics, id) => {
     const verifiedParticipants = ageMetrics.verifiedParticipants ? ageMetrics.verifiedParticipants : 0
 
-    const participantAgeRange1 = ageMetrics['40-45'] !== undefined ? ageMetrics['40-45'] : 0;
-    const participantAgeRange2 = ageMetrics['46-50'] !== undefined ? ageMetrics['46-50'] : 0;
-    const participantAgeRange3 = ageMetrics['51-55'] !== undefined ? ageMetrics['51-55'] : 0;
-    const participantAgeRange4 = ageMetrics['56-60'] !== undefined ? ageMetrics['56-60'] : 0;
-    const participantAgeRange5 = ageMetrics['61-65'] !== undefined ? ageMetrics['61-65'] : 0;
+    const participantAgeRange1 = ageMetrics['30-34'] !== undefined ? ageMetrics['30-34'] : 0;
+    const participantAgeRange2 = ageMetrics['35-39'] !== undefined ? ageMetrics['35-39'] : 0;
+    const participantAgeRange3 = ageMetrics['40-45'] !== undefined ? ageMetrics['40-45'] : 0;
+    const participantAgeRange4 = ageMetrics['46-50'] !== undefined ? ageMetrics['46-50'] : 0;
+    const participantAgeRange5 = ageMetrics['51-55'] !== undefined ? ageMetrics['51-55'] : 0;
+    const participantAgeRange6 = ageMetrics['56-60'] !== undefined ? ageMetrics['56-60'] : 0;
+    const participantAgeRange7 = ageMetrics['61-65'] !== undefined ? ageMetrics['61-65'] : 0;
+    const participantAgeRange8 = ageMetrics['66-70'] !== undefined ? ageMetrics['66-70'] : 0;
 
     const participantAgeRangeResponse1 = ((participantAgeRange1)/(verifiedParticipants)*100).toFixed(1);
     const participantAgeRangeResponse2 = ((participantAgeRange2)/(verifiedParticipants)*100).toFixed(1);
     const participantAgeRangeResponse3 = ((participantAgeRange3)/(verifiedParticipants)*100).toFixed(1);
     const participantAgeRangeResponse4 = ((participantAgeRange4)/(verifiedParticipants)*100).toFixed(1);
     const participantAgeRangeResponse5 = ((participantAgeRange5)/(verifiedParticipants)*100).toFixed(1);
+    const participantAgeRangeResponse6 = ((participantAgeRange6)/(verifiedParticipants)*100).toFixed(1);
+    const participantAgeRangeResponse7 = ((participantAgeRange7)/(verifiedParticipants)*100).toFixed(1);
+    const participantAgeRangeResponse8 = ((participantAgeRange8)/(verifiedParticipants)*100).toFixed(1);
 
     let data = [{
-        values: [participantAgeRangeResponse1, participantAgeRangeResponse2, participantAgeRangeResponse3, participantAgeRangeResponse4, participantAgeRangeResponse5],
-        labels: [ `40-45: N = ${participantAgeRange1}`, 
-                    `46-50: N = ${participantAgeRange2}`, 
-                    `51-55: N = ${participantAgeRange3}`,
-                    `56-60: N = ${participantAgeRange4}`, 
-                    `61-65: N = ${participantAgeRange5}`],
+        values: [participantAgeRangeResponse1, participantAgeRangeResponse2, participantAgeRangeResponse3, participantAgeRangeResponse4, participantAgeRangeResponse5, participantAgeRangeResponse6, participantAgeRangeResponse7, participantAgeRangeResponse8],
+        labels: [   `30-34: N = ${participantAgeRange1}`, 
+                    `35-39: N = ${participantAgeRange2}`,
+                    `40-45: N = ${participantAgeRange3}`, 
+                    `46-50: N = ${participantAgeRange4}`, 
+                    `51-55: N = ${participantAgeRange5}`,
+                    `56-60: N = ${participantAgeRange6}`, 
+                    `61-65: N = ${participantAgeRange7}`,
+                    `66-70: N = ${participantAgeRange8}`
+                ],
         hoverinfo: 'label+value',
         type: 'pie'
       }];

--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -580,19 +580,19 @@ const tableTemplate = (data, showButtons) => {
                 template += `<td>${participant[fieldMapping.suspendContact.toString()] ? participant[fieldMapping.suspendContact.toString()].split('T')[0] : ``}</td>`)
             : (x === fieldMapping.siteReportedAge.toString()) ? 
             (
-                ( participant['state'][fieldMapping.siteReportedAge.toString()] === fieldMapping.ageRange6 ) ?
+                ( participant['state'][fieldMapping.siteReportedAge.toString()] === fieldMapping.ageRange1 ) ?
                     template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `30-34` : ``}</td>`
-                :   ( participant['state'][fieldMapping.siteReportedAge.toString()] === fieldMapping.ageRange7 ) ?
-                    template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `35-39` : ``}</td>`
-                :   ( participant['state'][fieldMapping.siteReportedAge.toString()] === fieldMapping.ageRange1 ) ?
-                    template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `40-45` : ``}</td>`
                 :   ( participant['state'][fieldMapping.siteReportedAge.toString()] === fieldMapping.ageRange2 ) ?
-                    template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `46-50` : ``}</td>`
+                    template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `35-39` : ``}</td>`
                 :   ( participant['state'][fieldMapping.siteReportedAge.toString()] === fieldMapping.ageRange3 ) ?
-                    template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `51-55` : ``}</td>`
+                    template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `40-45` : ``}</td>`
                 :   ( participant['state'][fieldMapping.siteReportedAge.toString()] === fieldMapping.ageRange4 ) ?
-                    template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `56-60` : ``}</td>`
+                    template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `46-50` : ``}</td>`
                 :   ( participant['state'][fieldMapping.siteReportedAge.toString()] === fieldMapping.ageRange5 ) ?
+                    template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `51-55` : ``}</td>`
+                :   ( participant['state'][fieldMapping.siteReportedAge.toString()] === fieldMapping.ageRange6 ) ?
+                    template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `56-60` : ``}</td>`
+                :   ( participant['state'][fieldMapping.siteReportedAge.toString()] === fieldMapping.ageRange7 ) ?
                     template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `61-65` : ``}</td>`
                 :   ( participant['state'][fieldMapping.siteReportedAge.toString()] === fieldMapping.ageRange8 ) ?
                     template += `<td>${participant['state'][fieldMapping.siteReportedAge.toString()] ? `66-70` : ``}</td>`


### PR DESCRIPTION
This PR addresses following issue:
https://github.com/episphere/connect/issues/848

Following CIDs are added:
"30-34": "713781738",
"35-39": "631272782",
"66-70": "722846087",

Code was updated to reflect new CIDs at age metrics & all participants table

PoC:
![Screenshot 2024-01-16 at 2 09 12 PM](https://github.com/episphere/connect/assets/30497847/d7039aed-7320-4fd5-a86a-69fea5ba3225)
![Screenshot 2024-01-16 at 2 09 37 PM](https://github.com/episphere/connect/assets/30497847/8353d336-5c10-4b01-8577-37d73fec70e7)
![Screenshot 2024-01-16 at 2 09 58 PM](https://github.com/episphere/connect/assets/30497847/4d341776-015e-4e4f-9b62-8acba1602698)
