### PR TITLE
SiteManager Dashboard: Add Data Corrections Tool (Part 2)

### DIFF
--- a/siteManagerDashboard/participantVerficationTool.js
+++ b/siteManagerDashboard/participantVerficationTool.js
@@ -110,7 +110,6 @@ export const renderVerificationTool = (participant) => {
             </div>
         </div>
     </div>`
-                                        console.log('ddd', participant)
     return template;
 }
 


### PR DESCRIPTION
This PR addresses following bug:
- When multiple updates to the Duplicate Type are made, this accidentally sets the Duplicate Type to NULL if the participant verification status is set to Duplicate.

Related Issue: https://github.com/episphere/connect/issues/810
Related PR: 
https://github.com/episphere/dashboard/pull/599
https://github.com/episphere/connectFaas/pull/514