### PR TITLE
PROMIS Survey Updates (Study Manager Dashboard)

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -82,7 +82,7 @@ export default
     "started": 1,
     "submitted": 2,
 
-    "notYetEligible1:": 789789789,
+    "notYetEligible1:": 789467219,
     "notStarted1": 972455046,
     "started1": 615768760,
     "submitted1": 231311385,

--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -82,6 +82,7 @@ export default
     "started": 1,
     "submitted": 2,
 
+    "notYetEligible1:": 789789789,
     "notStarted1": 972455046,
     "started1": 615768760,
     "submitted1": 231311385,

--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -162,6 +162,10 @@ export default
     "mouthwashSurveyStartedDate": 286191859,
     "mouthwashSurveyCompletedDate": 195145666,
 
+    "promisSurveyFlag": 320303124,
+    "promisSurveyStartedDate": 870643066,
+    "promisSurveyCompletedDate": 843688458,
+
     'combinedBoodUrineMouthwashSurvey': 265193023,
     'combinedBoodUrineMouthwashSurveyStartDate': 822499427,
     'combinedBoodUrineMouthwashSurveyCompleteDate': 222161762,

--- a/siteManagerDashboard/participantSummary.js
+++ b/siteManagerDashboard/participantSummary.js
@@ -3,7 +3,7 @@ import { renderParticipantHeader } from './participantHeader.js';
 import fieldMapping from './fieldToConceptIdMapping.js';
 import { userProfile, verificationStatus, baselineBOHSurvey, baselineMRESurvey,baselineSASSurvey, 
     baselineLAWSurvey, baselineSSN, baselineCOVIDSurvey, baselineBloodSample, baselineUrineSample, baselineBiospecSurvey, baselineMenstrualSurvey,
-    baselineMouthwashSample, baselineBloodUrineSurvey, baselineMouthwashSurvey, baselineEMR, baselinePayment } from './participantSummaryRow.js';
+    baselineMouthwashSample, baselineBloodUrineSurvey, baselineMouthwashSurvey, baselinePromisSurvey, baselineEMR, baselinePayment } from './participantSummaryRow.js';
 import { humanReadableMDY, conceptToSiteMapping, pdfCoordinatesMap } from './utils.js';
 
 const { PDFDocument, StandardFonts } = PDFLib
@@ -94,6 +94,9 @@ export const render = (participant) => {
                                 </tr>
                                 <tr class="row-color-survey-light">
                                     ${baselineMouthwashSurvey(participant)}
+                                </tr>
+                                <tr class="row-color-survey-dark">
+                                    ${baselinePromisSurvey(participant)}
                                 </tr>
                                 <tr class="row-color-sample-dark">
                                     ${baselineBloodSample(participant)}

--- a/siteManagerDashboard/participantSummaryRow.js
+++ b/siteManagerDashboard/participantSummaryRow.js
@@ -385,6 +385,30 @@ export const baselineMouthwashSurvey = (participantModule) => {
     return template;
 };
 
+export const baselinePromisSurvey = (participantModule) => {
+    const isDataDestroyed = participantModule[fieldMapping.dataHasBeenDestroyed];
+    const refusedSurveyOption = participant[fieldMapping.refusalOptions]?.[fieldMapping.refusedSurvey];
+    let template = ``;
+    
+    if (isDataDestroyed === fieldMapping.yes) {
+        template += getTemplateRow("fa fa-times fa-2x", "color: red", "Follow-Up 3-mo", "Survey", "Quality of Life", "Data Destroyed", "N/A", "N/A", "N", "N/A");
+    } else if (refusedSurveyOption === fieldMapping.yes) {
+        template += getTemplateRow("fa fa-times fa-2x", "color: red", "Follow-Up 3-mo", "Survey", "Quality of Life", "N/A", "N/A", "N/A", "Y", "N/A");
+    } else if (!participantModule) {
+        template += getTemplateRow("fa fa-times fa-2x", "color: red", "Follow-Up 3-mo", "Survey", "Quality of Life", "N/A", "N/A", "N/A", "N", "N/A");
+    } else if (participantModule[fieldMapping.promisSurveyFlag] === fieldMapping.submitted1) {
+        template += getTemplateRow("fa fa-check fa-2x", "color: green", "Follow-Up 3-mo", "Survey", "Quality of Life", "Submitted",
+        humanReadableMDY(participantModule[fieldMapping.promisSurveyCompletedDate]), "N/A", "N", "N/A");
+    } else if (participantModule[fieldMapping.promisSurveyFlag] === fieldMapping.started1) {
+        template += getTemplateRow("fa fa-hashtag fa-2x", "color: orange", "Follow-Up 3-mo", "Survey", "Quality of Life", "Started",
+        humanReadableMDY(participantModule[fieldMapping.promisSurveyStartedDate]), "N/A", "N", "N/A");
+    } else {
+        template += getTemplateRow("fa fa-times fa-2x", "color: red", "Follow-Up 3-mo", "Survey", "Quality of Life", "Not Started", "N/A", "N/A", "N", "N/A");
+    }
+
+    return template;
+};
+
 export const baselineMenstrualSurvey = (participant) => {
     const isDataDestroyed = participant[fieldMapping.dataHasBeenDestroyed]
     let template = ``;

--- a/siteManagerDashboard/participantSummaryRow.js
+++ b/siteManagerDashboard/participantSummaryRow.js
@@ -402,6 +402,8 @@ export const baselinePromisSurvey = (participantModule) => {
     } else if (participantModule[fieldMapping.promisSurveyFlag] === fieldMapping.started1) {
         template += getTemplateRow("fa fa-hashtag fa-2x", "color: orange", "Follow-Up 3-mo", "Survey", "Quality of Life", "Started",
         humanReadableMDY(participantModule[fieldMapping.promisSurveyStartedDate]), "N/A", "N", "N/A");
+    } else if (participantModule[fieldMapping.promisSurveyFlag] === fieldMapping.notYetEligible1) {
+        template += getTemplateRow("fa fa-times fa-2x", "color: red", "Follow-Up 3-mo", "Survey", "Quality of Life", "Not Yet Eligible", "N/A", "N/A", "N", "N/A");
     } else {
         template += getTemplateRow("fa fa-times fa-2x", "color: red", "Follow-Up 3-mo", "Survey", "Quality of Life", "Not Started", "N/A", "N/A", "N", "N/A");
     }


### PR DESCRIPTION
This PR addresses the following Issue:
* https://github.com/episphere/connect/issues/878
-----
## Background Details
* With the new PROMIS QOL Survey being added to the study we need to display the status of the survey for each participant on the Participant Summary page.
-----
## Technical Changes
* Added new survey status Concept ID and PROMIS survey Concept IDs to `fieldToConceptIdMapping.js`
* Added HTML block to `participantSummary.js`
* Added function `baselinePromisSurvey()` to `participantSummaryRow.js` to calculate and render row for PROMIS survey
 