### PR TITLE
QOL Survey Refusal Options

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -298,6 +298,8 @@ export default
     'refusedSpecimenSurevys': 217367618,
     'refusedFutureSurveys': 867203506,
     'refusedFutureSamples': 352996056,
+    'refusedQualityOfLifeSurvey': 936015433,
+    'refusedAllFutureQualityOfLifeSurveys': 688142378,
     
     'refusedAllFutureActivities': 906417725,
     'revokeHIPAA': 773707518,
@@ -453,6 +455,8 @@ export default
     'refBaselineAllFutureSpecimensTimeStamp': 711256590,
     'refBaselineSpecimenSurveysTimeStamp': 657475009,
     'refAllFutureActivitesTimeStamp': 614264509,
+    'refQualityOfLifeSurveyTimeStamp': 667960135,
+    'refAllFutureQualityOfLifeSurveysTimeStamp': 953225775,
 
     // remaining withdrawal
     'contactSuspended': 726389747,

--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -24,7 +24,7 @@ export const renderTable = (data, source) => {
     fieldMapping.address1, fieldMapping.address2, fieldMapping.city, fieldMapping.state, fieldMapping.zip, fieldMapping.email, fieldMapping.email1, 
     fieldMapping.email2, fieldMapping.cellPhone, fieldMapping.homePhone, fieldMapping.otherPhone, fieldMapping.previousCancer, fieldMapping.allBaselineSurveysCompleted, 
     fieldMapping.participationStatus, fieldMapping.bohStatusFlag1, fieldMapping.mreStatusFlag1, fieldMapping.sasStatusFlag1, fieldMapping.lawStausFlag1, 
-    fieldMapping.ssnFullflag, fieldMapping.ssnPartialFlag , fieldMapping.refusedSurvey,  fieldMapping.refusedBlood, fieldMapping.refusedUrine,  fieldMapping.refusedMouthwash, fieldMapping.refusedSpecimenSurevys, fieldMapping.refusedFutureSamples, 
+    fieldMapping.ssnFullflag, fieldMapping.ssnPartialFlag , fieldMapping.refusedSurvey,  fieldMapping.refusedBlood, fieldMapping.refusedUrine,  fieldMapping.refusedMouthwash, fieldMapping.refusedSpecimenSurevys, fieldMapping.refusedFutureSamples, fieldMapping.refusedQualityOfLifeSurvey, fieldMapping.refusedAllFutureQualityOfLifeSurveys,
     fieldMapping.refusedFutureSurveys, fieldMapping.refusedAllFutureActivities, fieldMapping.revokeHIPAA, fieldMapping.dateHipaaRevokeRequested, fieldMapping.dateHIPAARevoc, fieldMapping.withdrawConsent, fieldMapping.dateWithdrewConsentRequested, 
     fieldMapping.participantDeceased, fieldMapping.dateOfDeath, fieldMapping.destroyData, fieldMapping.dateDataDestroyRequested, fieldMapping.dateDataDestroy, fieldMapping.suspendContact
  ];
@@ -558,7 +558,7 @@ const tableTemplate = (data, showButtons) => {
             )
             :  (x === (fieldMapping.refusedSurvey).toString() || x === (fieldMapping.refusedBlood).toString() || x === (fieldMapping.refusedUrine).toString() ||
                 x === (fieldMapping.refusedMouthwash).toString() || x === (fieldMapping.refusedSpecimenSurevys).toString() || x === (fieldMapping.refusedFutureSamples).toString() || 
-                x === (fieldMapping.refusedFutureSurveys).toString()) ?
+                x === (fieldMapping.refusedFutureSurveys).toString() || x === (fieldMapping.refusedQualityOfLifeSurvey).toString() || x === (fieldMapping.refusedAllFutureQualityOfLifeSurveys).toString()) ?
             (
                 (participant[fieldMapping.refusalOptions]?.[x] === fieldMapping.yes ?
                     ( template += `<td>${participant[fieldMapping.refusalOptions]?.[x] ? 'Yes'  : ''}</td>` )

--- a/siteManagerDashboard/participantSummaryRow.js
+++ b/siteManagerDashboard/participantSummaryRow.js
@@ -385,24 +385,27 @@ export const baselineMouthwashSurvey = (participantModule) => {
     return template;
 };
 
-export const baselinePromisSurvey = (participantModule) => {
-    const isDataDestroyed = participantModule[fieldMapping.dataHasBeenDestroyed];
-    const refusedSurveyOption = participant[fieldMapping.refusalOptions]?.[fieldMapping.refusedSurvey];
+export const baselinePromisSurvey = (participant) => {
+    const isDataDestroyed = participant[fieldMapping.dataHasBeenDestroyed];
+    const refusedAllFutureSurveys = participant[fieldMapping.refusalOptions]?.[fieldMapping.refusedFutureSurveys];
+    const refusedAllFutureActivities = participant[fieldMapping.refusalOptions]?.[fieldMapping.refusedAllFutureActivities];
+    const refusedQualityOfLifeSurvey = participant[fieldMapping.refusalOptions]?.[fieldMapping.refusedQualityOfLifeSurvey];
+
     let template = ``;
     
     if (isDataDestroyed === fieldMapping.yes) {
         template += getTemplateRow("fa fa-times fa-2x", "color: red", "Follow-Up 3-mo", "Survey", "Quality of Life", "Data Destroyed", "N/A", "N/A", "N", "N/A");
-    } else if (refusedSurveyOption === fieldMapping.yes) {
+    } else if (refusedAllFutureSurveys === fieldMapping.yes || refusedAllFutureActivities === fieldMapping.yes || refusedQualityOfLifeSurvey === fieldMapping.yes) {
         template += getTemplateRow("fa fa-times fa-2x", "color: red", "Follow-Up 3-mo", "Survey", "Quality of Life", "N/A", "N/A", "N/A", "Y", "N/A");
-    } else if (!participantModule) {
+    } else if (!participant) {
         template += getTemplateRow("fa fa-times fa-2x", "color: red", "Follow-Up 3-mo", "Survey", "Quality of Life", "N/A", "N/A", "N/A", "N", "N/A");
-    } else if (participantModule[fieldMapping.promisSurveyFlag] === fieldMapping.submitted1) {
+    } else if (participant[fieldMapping.promisSurveyFlag] === fieldMapping.submitted1) {
         template += getTemplateRow("fa fa-check fa-2x", "color: green", "Follow-Up 3-mo", "Survey", "Quality of Life", "Submitted",
-        humanReadableMDY(participantModule[fieldMapping.promisSurveyCompletedDate]), "N/A", "N", "N/A");
-    } else if (participantModule[fieldMapping.promisSurveyFlag] === fieldMapping.started1) {
+        humanReadableMDY(participant[fieldMapping.promisSurveyCompletedDate]), "N/A", "N", "N/A");
+    } else if (participant[fieldMapping.promisSurveyFlag] === fieldMapping.started1) {
         template += getTemplateRow("fa fa-hashtag fa-2x", "color: orange", "Follow-Up 3-mo", "Survey", "Quality of Life", "Started",
-        humanReadableMDY(participantModule[fieldMapping.promisSurveyStartedDate]), "N/A", "N", "N/A");
-    } else if (participantModule[fieldMapping.promisSurveyFlag] === fieldMapping.notYetEligible1) {
+        humanReadableMDY(participant[fieldMapping.promisSurveyStartedDate]), "N/A", "N", "N/A");
+    } else if (participant[fieldMapping.promisSurveyFlag] === fieldMapping.notYetEligible1) {
         template += getTemplateRow("fa fa-times fa-2x", "color: red", "Follow-Up 3-mo", "Survey", "Quality of Life", "Not Yet Eligible", "N/A", "N/A", "N", "N/A");
     } else {
         template += getTemplateRow("fa fa-times fa-2x", "color: red", "Follow-Up 3-mo", "Survey", "Quality of Life", "Not Started", "N/A", "N/A", "N", "N/A");

--- a/siteManagerDashboard/participantWithdrawal.js
+++ b/siteManagerDashboard/participantWithdrawal.js
@@ -75,6 +75,8 @@ const getParticipantSelectedRefusals = (participant) => {
     if (participant[fieldMapping.refusalOptions][fieldMapping.refusedMouthwash] === fieldMapping.yes ) template += `Baseline Mouthwash (Saliva) Donation, ` 
     if (participant[fieldMapping.refusalOptions][fieldMapping.refusedSpecimenSurevys] === fieldMapping.yes ) template += `Baseline Specimen Surveys, `
     if (participant[fieldMapping.refusalOptions][fieldMapping.refusedFutureSamples] === fieldMapping.yes ) template += `All future specimens (willing to do surveys)​​, `
+    if (participant[fieldMapping.refusalOptions][fieldMapping.refusedQualityOfLifeSurvey] === fieldMapping.yes ) template += `Refused QOL survey 3-mo (but willing to do other future surveys)​, `
+    if (participant[fieldMapping.refusalOptions][fieldMapping.refusedAllFutureQualityOfLifeSurveys] === fieldMapping.yes ) template += `Refused all future QOL surveys (but willing to do other future surveys)​, `
     if (participant[fieldMapping.refusalOptions][fieldMapping.refusedFutureSurveys] === fieldMapping.yes ) template += `All future surveys (willing to do specimens)​, ` 
     if (participant[fieldMapping.refusedAllFutureActivities] === fieldMapping.yes ) template += `All Future Study Activities, ` 
     if (participant[fieldMapping.revokeHIPAA] === fieldMapping.yes ) template += `Revoke HIPAA Authorization, `

--- a/siteManagerDashboard/participantWithdrawalForm.js
+++ b/siteManagerDashboard/participantWithdrawalForm.js
@@ -64,6 +64,18 @@ export const renderParticipantWithdrawalLandingPage = () => {
                                     <div class="form-check">
                                         <span><i><b>Surveys</b></i></span>
                                         <br />
+                                        <input class="form-check-input" name="options" type="checkbox" value="Quality of Life 3-Mo Survey (but willing to do other future surveys)" 
+                                        data-optionKey=${fieldMapping.refusedQualityOfLifeSurvey} id="refusedQualityOfLifeSurveyCheck">
+                                        <label class="form-check-label" for="refusedQualityOfLifeSurveyCheck">
+                                            Quality of Life 3-Mo Survey (but willing to do other future surveys)
+                                        </label>
+                                        <br />
+                                        <input class="form-check-input" name="options" type="checkbox" value="All future QOL Surveys (but willing to do other future surveys)" 
+                                        data-optionKey=${fieldMapping.refusedAllFutureQualityOfLifeSurveys} id="refusedAllFutureQualityOfLifeSurveysCheck">
+                                        <label class="form-check-label" for="refusedAllFutureQualityOfLifeSurveysCheck">
+                                            All future QOL Surveys (but willing to do other future surveys)
+                                        </label>
+                                        <br />
                                         <input class="form-check-input" name="options" type="checkbox" value="All future surveys (willing to do specimens)" 
                                         data-optionKey=${fieldMapping.refusedFutureSurveys} id="defaultCheck6">
                                         <label class="form-check-label" for="defaultCheck6">
@@ -448,29 +460,35 @@ const sendResponses = async (finalOptions, retainOptions, requestedHolder, sourc
     sendRefusalData[fieldMapping.refusalOptions] = {};
     retainOptions.forEach(x => {
         if (parseInt(x.dataset.optionkey) === fieldMapping.refusedSurvey) {
-                setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineSurveyTimeStamp);
-            }
+            setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineSurveyTimeStamp);
+        }
         else if (parseInt(x.dataset.optionkey) === fieldMapping.refusedBlood) {
-                setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineBloodTimeStamp);
-            }
+            setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineBloodTimeStamp);
+        }
         else if (parseInt(x.dataset.optionkey) === fieldMapping.refusedUrine) {
-                setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineUrineTimeStamp);
-            }
+            setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineUrineTimeStamp);
+        }
         else if (parseInt(x.dataset.optionkey) ===  fieldMapping.refusedMouthwash) {
-                setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineMouthwashTimeStamp);
-            }
+            setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineMouthwashTimeStamp);
+        }
         else if (parseInt(x.dataset.optionkey) ===  fieldMapping.refusedSpecimenSurevys) {
-                setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineSpecimenSurveysTimeStamp);
+            setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineSpecimenSurveysTimeStamp);
         }
         else if (parseInt(x.dataset.optionkey) ===  fieldMapping.refusedFutureSurveys) {
-                setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineAllFutureSurveysTimeStamp);
+            setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineAllFutureSurveysTimeStamp);
         }
         else if (parseInt(x.dataset.optionkey) ===  fieldMapping.refusedFutureSamples) {
-                setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineAllFutureSpecimensTimeStamp);
+            setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineAllFutureSpecimensTimeStamp);
+        }
+        else if (parseInt(x.dataset.optionkey) ===  fieldMapping.refusedQualityOfLifeSurvey) {
+            setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refQualityOfLifeSurveyTimeStamp);
+        }
+        else if (parseInt(x.dataset.optionkey) ===  fieldMapping.refusedAllFutureQualityOfLifeSurveys) {
+            setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refAllFutureQualityOfLifeSurveysTimeStamp);
         }
         else {
-                sendRefusalData[x.dataset.optionkey] = fieldMapping.yes
-            }
+            sendRefusalData[x.dataset.optionkey] = fieldMapping.yes
+        }
     })
     if (requestedHolder.length != 0) {
         requestedHolder.forEach(x => {


### PR DESCRIPTION
This PR addresses the following Issues:
* https://github.com/episphere/connect/issues/878
* https://github.com/episphere/connect/issues/881
-----
## Background Details
* With the new PROMIS QOL Survey being added to the study we need to add a couple of new options on the Participant Refusal / Withdrawals page
-----
## Technical Changes
* Added new Concept ID constants to `fieldToConceptIdMapping.js`
* Added new `renderTable()` column headers and `tableTemplate()` data row values in `participantCommons.js`
* Updated and cleaned up `baselinePromisSurvey()` in `participantSummaryRow.js`
* Added new options to `getParticipantSelectedRefusals()` in `participantWithDrawal.js`
* Added new check boxes and timestamps to `participantWithdrawalForm.js`
 