### PR TITLE
PROMIS Survey Updates (Study Manager Dashboard)

### DIFF
--- a/siteManagerDashboard/participantSummaryRow.js
+++ b/siteManagerDashboard/participantSummaryRow.js
@@ -388,7 +388,7 @@ export const baselineMouthwashSurvey = (participantModule) => {
 export const baselinePromisSurvey = (participant) => {
     const isDataDestroyed = participant[fieldMapping.dataHasBeenDestroyed];
     const refusedAllFutureSurveys = participant[fieldMapping.refusalOptions]?.[fieldMapping.refusedFutureSurveys];
-    const refusedAllFutureActivities = participant[fieldMapping.refusalOptions]?.[fieldMapping.refusedAllFutureActivities];
+    const refusedAllFutureActivities = participant[fieldMapping.refusedAllFutureActivities];
     const refusedQualityOfLifeSurvey = participant[fieldMapping.refusalOptions]?.[fieldMapping.refusedQualityOfLifeSurvey];
 
     let template = ``;


### PR DESCRIPTION
This PR addresses a bug found in the following Pull Request:
* https://github.com/episphere/dashboard/pull/615
-----
## Background Details
* One of the Refusal conditionalities was mistyped and shouldn't have been nested under Concept ID `685002411`
-----
## Technical Changes
* Removed `[fieldMapping.refusalOptions]` nesting when setting variable `refusedAllFutureActivities` in `participantSummaryRow.js`
 