### PR TITLE
Display concept ids for dateHipaaRevokeRequested and refusedSpecimenSurveys correctly

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -295,7 +295,7 @@ export default
     // 'refusedBloodSample': 194410742,
     // 'refusedUrineSample': 949501163,
     // 'refusedMouthwashSample': 277479354,
-    'refusedSpecimenSurevys': 217367618,
+    'refusedSpecimenSurveys': 217367618,
     'refusedFutureSurveys': 867203506,
     'refusedFutureSamples': 352996056,
     'refusedQualityOfLifeSurvey': 936015433,

--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -24,18 +24,18 @@ export const renderTable = (data, source) => {
     fieldMapping.address1, fieldMapping.address2, fieldMapping.city, fieldMapping.state, fieldMapping.zip, fieldMapping.email, fieldMapping.email1, 
     fieldMapping.email2, fieldMapping.cellPhone, fieldMapping.homePhone, fieldMapping.otherPhone, fieldMapping.previousCancer, fieldMapping.allBaselineSurveysCompleted, 
     fieldMapping.participationStatus, fieldMapping.bohStatusFlag1, fieldMapping.mreStatusFlag1, fieldMapping.sasStatusFlag1, fieldMapping.lawStausFlag1, 
-    fieldMapping.ssnFullflag, fieldMapping.ssnPartialFlag , fieldMapping.refusedSurvey,  fieldMapping.refusedBlood, fieldMapping.refusedUrine,  fieldMapping.refusedMouthwash, fieldMapping.refusedSpecimenSurevys, fieldMapping.refusedFutureSamples, fieldMapping.refusedQualityOfLifeSurvey, fieldMapping.refusedAllFutureQualityOfLifeSurveys,
+    fieldMapping.ssnFullflag, fieldMapping.ssnPartialFlag , fieldMapping.refusedSurvey,  fieldMapping.refusedBlood, fieldMapping.refusedUrine,  fieldMapping.refusedMouthwash, fieldMapping.refusedSpecimenSurveys, fieldMapping.refusedFutureSamples, fieldMapping.refusedQualityOfLifeSurvey, fieldMapping.refusedAllFutureQualityOfLifeSurveys,
     fieldMapping.refusedFutureSurveys, fieldMapping.refusedAllFutureActivities, fieldMapping.revokeHIPAA, fieldMapping.dateHipaaRevokeRequested, fieldMapping.dateHIPAARevoc, fieldMapping.withdrawConsent, fieldMapping.dateWithdrewConsentRequested, 
-    fieldMapping.participantDeceased, fieldMapping.dateOfDeath, fieldMapping.destroyData, fieldMapping.dateDataDestroyRequested, fieldMapping.dateDataDestroy, fieldMapping.suspendContact
+    fieldMapping.participantDeceased, fieldMapping.dateOfDeath, fieldMapping.destroyData, fieldMapping.dateDataDestroyRequested, fieldMapping.dateDataDestroy, fieldMapping.suspendContact, 
  ];
     localStorage.removeItem("participant");
     let conceptIdMapping = JSON.parse(localStorage.getItem('conceptIdMapping'));
     if (conceptIdMapping) {
+        
         template += `<div class="row">
             <div class="col" id="columnFilter">
                 ${array.map(x => `<button name="column-filter" class="filter-btn sub-div-shadow" data-column="${x}">${conceptIdMapping[x] && conceptIdMapping[x] ? 
-                    ((x !== fieldMapping.refusedSpecimenSurevys && x !== fieldMapping.dateHipaaRevokeRequested &&
-                        x !== fieldMapping.consentFirstName && x !== fieldMapping.consentMiddleName && x !== fieldMapping.consentLastName) ? 
+                    ((x !== fieldMapping.consentFirstName && x !== fieldMapping.consentMiddleName && x !== fieldMapping.consentLastName) ? 
                         conceptIdMapping[x]['Variable Label'] || conceptIdMapping[x]['Variable Name'] : getCustomVariableNames(x)) : x}</button>`)}
             </div>
         </div>`
@@ -576,7 +576,7 @@ const tableTemplate = (data, showButtons) => {
                 : (template += `<td>${participant[x] ? 'Not Started'  : ''}</td>` )
             )
             :  (x === (fieldMapping.refusedSurvey).toString() || x === (fieldMapping.refusedBlood).toString() || x === (fieldMapping.refusedUrine).toString() ||
-                x === (fieldMapping.refusedMouthwash).toString() || x === (fieldMapping.refusedSpecimenSurevys).toString() || x === (fieldMapping.refusedFutureSamples).toString() || 
+                x === (fieldMapping.refusedMouthwash).toString() || x === (fieldMapping.refusedSpecimenSurveys).toString() || x === (fieldMapping.refusedFutureSamples).toString() || 
                 x === (fieldMapping.refusedFutureSurveys).toString() || x === (fieldMapping.refusedQualityOfLifeSurvey).toString() || x === (fieldMapping.refusedAllFutureQualityOfLifeSurveys).toString()) ?
             (
                 (participant[fieldMapping.refusalOptions]?.[x] === fieldMapping.yes ?
@@ -1059,8 +1059,6 @@ export const renderLookupSiteDropdown = () => {
 
 const getCustomVariableNames = (x) => {
     const customVariableFields = {
-                                    [fieldMapping.refusedSpecimenSurevys]: 'Refused baseline specimen surveys',
-                                    [fieldMapping.dateHipaaRevokeRequested]: 'Date revoked HIPAA',
                                     [fieldMapping.consentFirstName]: 'First Name (Consent)',
                                     [fieldMapping.consentMiddleName]: 'Middle Name (Consent)',
                                     [fieldMapping.consentLastName]: 'Last Name (Consent)',

--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -26,12 +26,11 @@ export const renderTable = (data, source) => {
     fieldMapping.participationStatus, fieldMapping.bohStatusFlag1, fieldMapping.mreStatusFlag1, fieldMapping.sasStatusFlag1, fieldMapping.lawStausFlag1, 
     fieldMapping.ssnFullflag, fieldMapping.ssnPartialFlag , fieldMapping.refusedSurvey,  fieldMapping.refusedBlood, fieldMapping.refusedUrine,  fieldMapping.refusedMouthwash, fieldMapping.refusedSpecimenSurveys, fieldMapping.refusedFutureSamples, fieldMapping.refusedQualityOfLifeSurvey, fieldMapping.refusedAllFutureQualityOfLifeSurveys,
     fieldMapping.refusedFutureSurveys, fieldMapping.refusedAllFutureActivities, fieldMapping.revokeHIPAA, fieldMapping.dateHipaaRevokeRequested, fieldMapping.dateHIPAARevoc, fieldMapping.withdrawConsent, fieldMapping.dateWithdrewConsentRequested, 
-    fieldMapping.participantDeceased, fieldMapping.dateOfDeath, fieldMapping.destroyData, fieldMapping.dateDataDestroyRequested, fieldMapping.dateDataDestroy, fieldMapping.suspendContact, 
+    fieldMapping.participantDeceased, fieldMapping.dateOfDeath, fieldMapping.destroyData, fieldMapping.dateDataDestroyRequested, fieldMapping.dateDataDestroy, fieldMapping.suspendContact
  ];
     localStorage.removeItem("participant");
     let conceptIdMapping = JSON.parse(localStorage.getItem('conceptIdMapping'));
     if (conceptIdMapping) {
-        
         template += `<div class="row">
             <div class="col" id="columnFilter">
                 ${array.map(x => `<button name="column-filter" class="filter-btn sub-div-shadow" data-column="${x}">${conceptIdMapping[x] && conceptIdMapping[x] ? 

--- a/siteManagerDashboard/participantSummaryRow.js
+++ b/siteManagerDashboard/participantSummaryRow.js
@@ -315,7 +315,7 @@ export const baselineCOVIDSurvey = (participant) => {
 export const baselineBiospecSurvey = (participant) => {
     const isDataDestroyed = participant[fieldMapping.dataHasBeenDestroyed]
     let combinedBoodUrineMouthwashSurvey = participant[fieldMapping.combinedBoodUrineMouthwashSurvey] && participant[fieldMapping.combinedBoodUrineMouthwashSurvey];
-    let refusedSpecimenOption = participant[fieldMapping.refusalOptions] && participant[fieldMapping.refusalOptions][fieldMapping.refusedSpecimenSurevys];
+    let refusedSpecimenOption = participant[fieldMapping.refusalOptions] && participant[fieldMapping.refusalOptions][fieldMapping.refusedSpecimenSurveys];
     let template = ``;
 
     if (isDataDestroyed === fieldMapping.yes) {
@@ -339,7 +339,7 @@ export const baselineBiospecSurvey = (participant) => {
 
 export const baselineBloodUrineSurvey = (participant) => {
     const isDataDestroyed = participant[fieldMapping.dataHasBeenDestroyed]
-    let refusedSpecimenOption = participant[fieldMapping.refusalOptions] && participant[fieldMapping.refusalOptions][fieldMapping.refusedSpecimenSurevys];
+    let refusedSpecimenOption = participant[fieldMapping.refusalOptions] && participant[fieldMapping.refusalOptions][fieldMapping.refusedSpecimenSurveys];
     let template = ``;
     
     if (isDataDestroyed === fieldMapping.yes) {
@@ -363,7 +363,7 @@ export const baselineBloodUrineSurvey = (participant) => {
 
 export const baselineMouthwashSurvey = (participantModule) => {
     const isDataDestroyed = participantModule[fieldMapping.dataHasBeenDestroyed];
-    let refusedSpecimenOption = participantModule[fieldMapping.refusalOptions] && participantModule[fieldMapping.refusalOptions][fieldMapping.refusedSpecimenSurevys];
+    let refusedSpecimenOption = participantModule[fieldMapping.refusalOptions] && participantModule[fieldMapping.refusalOptions][fieldMapping.refusedSpecimenSurveys];
     let template = ``;
     
     if (isDataDestroyed === fieldMapping.yes) {

--- a/siteManagerDashboard/participantWithdrawal.js
+++ b/siteManagerDashboard/participantWithdrawal.js
@@ -73,7 +73,7 @@ const getParticipantSelectedRefusals = (participant) => {
     if (participant[fieldMapping.refusalOptions][fieldMapping.refusedBlood] === fieldMapping.yes ) template += `Baseline Blood Donation, `
     if (participant[fieldMapping.refusalOptions][fieldMapping.refusedUrine] === fieldMapping.yes )  template += `Baseline Urine Donation, `
     if (participant[fieldMapping.refusalOptions][fieldMapping.refusedMouthwash] === fieldMapping.yes ) template += `Baseline Mouthwash (Saliva) Donation, ` 
-    if (participant[fieldMapping.refusalOptions][fieldMapping.refusedSpecimenSurevys] === fieldMapping.yes ) template += `Baseline Specimen Surveys, `
+    if (participant[fieldMapping.refusalOptions][fieldMapping.refusedSpecimenSurveys] === fieldMapping.yes ) template += `Baseline Specimen Surveys, `
     if (participant[fieldMapping.refusalOptions][fieldMapping.refusedFutureSamples] === fieldMapping.yes ) template += `All future specimens (willing to do surveys)​​, `
     if (participant[fieldMapping.refusalOptions][fieldMapping.refusedQualityOfLifeSurvey] === fieldMapping.yes ) template += `Refused QOL survey 3-mo (but willing to do other future surveys)​, `
     if (participant[fieldMapping.refusalOptions][fieldMapping.refusedAllFutureQualityOfLifeSurveys] === fieldMapping.yes ) template += `Refused all future QOL surveys (but willing to do other future surveys)​, `

--- a/siteManagerDashboard/participantWithdrawalForm.js
+++ b/siteManagerDashboard/participantWithdrawalForm.js
@@ -52,7 +52,7 @@ export const renderParticipantWithdrawalLandingPage = () => {
                                         <span><i><b>Specimen Surveys</b></i></span>
                                         <br />
                                         <input class="form-check-input" name="options" type="checkbox" value="Baseline Specimen Surveys" 
-                                        data-optionKey=${fieldMapping.refusedSpecimenSurevys} id="defaultCheck5">
+                                        data-optionKey=${fieldMapping.refusedSpecimenSurveys} id="defaultCheck5">
                                         <label class="form-check-label" for="defaultCheck5">
                                             Baseline Specimen Surveys
                                         </label>
@@ -471,7 +471,7 @@ const sendResponses = async (finalOptions, retainOptions, requestedHolder, sourc
         else if (parseInt(x.dataset.optionkey) ===  fieldMapping.refusedMouthwash) {
             setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineMouthwashTimeStamp);
         }
-        else if (parseInt(x.dataset.optionkey) ===  fieldMapping.refusedSpecimenSurevys) {
+        else if (parseInt(x.dataset.optionkey) ===  fieldMapping.refusedSpecimenSurveys) {
             setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineSpecimenSurveysTimeStamp);
         }
         else if (parseInt(x.dataset.optionkey) ===  fieldMapping.refusedFutureSurveys) {


### PR DESCRIPTION
This PR is partially related to [issue#894](https://github.com/episphere/connect/issues/894)

Related links:
- https://github.com/episphere/connect/issues/894#issuecomment-1944280449

Problem:

The dateHipaaRevokeRequested (664453818) and refusedSpecimenSurveys (217367618) are referencing the `getCustomVariableNames` function in the mapping ternary logic. The concept Ids are suppose to reference the variable label value.

Code Changes:
- Removed `x !== fieldMapping.refusedSpecimenSurevys` and `x !== fieldMapping.dateHipaaRevokeRequested` from the mapping ternary logic so it doesn't reference `getCustomVariableNames` function
- Updated `refusedSpecimenSurveys` typo
- Remove `fieldMapping.refusedSpecimenSurevys` and `fieldMapping.dateHipaaRevokeRequested` in `getCustomVariableNames` function

Before:
<img width="871" alt="Screenshot 2024-03-20 at 7 02 17 PM" src="https://github.com/episphere/dashboard/assets/33293205/b4621c20-2c2a-4d81-bf52-103d79e5e21e">


After:
<img width="891" alt="Screenshot 2024-03-20 at 6 24 39 PM" src="https://github.com/episphere/dashboard/assets/33293205/47733167-ce75-42e6-b9cd-a1aab665692d">



