### PR TITLE
SMDB - Error in display fields in header for consent date and verification date

### DIFF
--- a/siteManagerDashboard/participantHeader.js
+++ b/siteManagerDashboard/participantHeader.js
@@ -47,14 +47,14 @@ export const renderParticipantHeader = (participant) => {
             template += `<span><b> DoB </b></span> : ${concatDOB(participant)} &nbsp;`
         :
         
-        (conceptIdMapping[headerImportantColumns[x].field] && conceptIdMapping[headerImportantColumns[x].field]['Variable Label'] === 'Consent submitted') ?
+        (conceptIdMapping[headerImportantColumns[x].field] && conceptIdMapping[headerImportantColumns[x].field]['Variable Label'] === 'Consent Sub') ?
             (participant[fieldMapping.consentFlag] === (fieldMapping.yes) ? 
                 template += `<span><b> Consented</b></span> : ${humanReadableMDY(participant[fieldMapping.consentDate])} &nbsp;`
                 :
                 template += `<span><b> Not Consented</b></span> : N/A &nbsp;`)
         :
 
-        (conceptIdMapping[headerImportantColumns[x].field] && conceptIdMapping[headerImportantColumns[x].field]['Variable Label'] === 'Verification status') ?
+        (conceptIdMapping[headerImportantColumns[x].field] && conceptIdMapping[headerImportantColumns[x].field]['Variable Label'] === 'Verif Status') ?
             (
                 (participant[fieldMapping.verifiedFlag] === fieldMapping.verified) ? 
                     (template += `<span><b> Verified</b></span> : ${humanReadableMDY(participant[fieldMapping.verficationDate])} &nbsp;`)


### PR DESCRIPTION
This pull request is related to issue#894 in the study manager dashboard:

- https://github.com/episphere/connect/issues/894

Problem:  Error in display fields in header for consent date and verification date. Concept Ids were being displayed instead of dates due to variable label changes in the `getMappings` function that fetches `https://raw.githubusercontent.com/episphere/conceptGithubActions/master/aggregate.json`

Code Changes:
Replace conditionals with updated variable labels