### PR TITLE
Add BSWH race/ethnicity smdb bubble fields & other fixes

### DIFF
--- a/siteManagerDashboard/fieldToConceptIdMapping.js
+++ b/siteManagerDashboard/fieldToConceptIdMapping.js
@@ -255,6 +255,18 @@ export default
 	"unaviableHLHF": 419709902,
 	"unaviableNHLHF": 896943397,
 	"unaviableEUHF": 519402449,
+
+    // Baylor Scott White & Health
+    'bswhReportedRaceEthnicity': 253532712,
+
+    // Reported race/ethnicity options (Other and Unavailable already exist)
+    "whiteNonHispanic":  723775357,
+    "blackNonHispanic": 153444133,
+    "hispanicLatino": 572474909,
+    "asian": 308427446,
+    "americanIndianOrAlaskanNative": 211228524,
+    "nativeHawaiianOrOtherPacificIslander": 277568192,
+    "multiRacial": 611398522 ,
     
     'siteReportedAge': 934298480,
     'siteReportedRace': 849518448,

--- a/siteManagerDashboard/index.js
+++ b/siteManagerDashboard/index.js
@@ -364,6 +364,7 @@ const renderSiteKeyList = () => {
             </button>
             <ul class="dropdown-menu" id="dropdownMenuButtonSites" aria-labelledby="dropdownMenuButton">
                 <li><a class="dropdown-item" data-siteKey="allResults" id="all">All</a></li>
+                <li><a class="dropdown-item" data-siteKey="BSWH" id="BSWH">Baylor Scott & White Health</a></li>
                 <li><a class="dropdown-item" data-siteKey="hfHealth" id="hfHealth">Henry Ford HS</a></li>
                 <li><a class="dropdown-item" data-siteKey="hPartners" id="hPartners">Health Partners</a></li>
                 <li><a class="dropdown-item" data-siteKey="kpGA" id="kpGA">KP GA</a></li>
@@ -374,7 +375,6 @@ const renderSiteKeyList = () => {
                 ${((location.host !== urls.prod) && (location.host !== urls.stage)) ? `<li><a class="dropdown-item" data-siteKey="nci" id="nci">NCI</a></li>` : ``}
                 <li><a class="dropdown-item" data-siteKey="snfrdHealth" id="snfrdHealth">Sanford Health</a></li>
                 <li><a class="dropdown-item" data-siteKey="uChiM" id="uChiM">UofC Medicine</a></li>
-                <li><a class="dropdown-item" data-siteKey="BSWH" id="BSWH">Baylor Scott & White Health</a></li>
             </ul>
         </div>
         `;

--- a/siteManagerDashboard/participantCommons.js
+++ b/siteManagerDashboard/participantCommons.js
@@ -26,7 +26,7 @@ export const renderTable = (data, source) => {
     fieldMapping.participationStatus, fieldMapping.bohStatusFlag1, fieldMapping.mreStatusFlag1, fieldMapping.sasStatusFlag1, fieldMapping.lawStausFlag1, 
     fieldMapping.ssnFullflag, fieldMapping.ssnPartialFlag , fieldMapping.refusedSurvey,  fieldMapping.refusedBlood, fieldMapping.refusedUrine,  fieldMapping.refusedMouthwash, fieldMapping.refusedSpecimenSurveys, fieldMapping.refusedFutureSamples, fieldMapping.refusedQualityOfLifeSurvey, fieldMapping.refusedAllFutureQualityOfLifeSurveys,
     fieldMapping.refusedFutureSurveys, fieldMapping.refusedAllFutureActivities, fieldMapping.revokeHIPAA, fieldMapping.dateHipaaRevokeRequested, fieldMapping.dateHIPAARevoc, fieldMapping.withdrawConsent, fieldMapping.dateWithdrewConsentRequested, 
-    fieldMapping.participantDeceased, fieldMapping.dateOfDeath, fieldMapping.destroyData, fieldMapping.dateDataDestroyRequested, fieldMapping.dateDataDestroy, fieldMapping.suspendContact
+    fieldMapping.participantDeceased, fieldMapping.dateOfDeath, fieldMapping.destroyData, fieldMapping.dateDataDestroyRequested, fieldMapping.dateDataDestroy, fieldMapping.suspendContact, fieldMapping.bswhReportedRaceEthnicity
  ];
     localStorage.removeItem("participant");
     let conceptIdMapping = JSON.parse(localStorage.getItem('conceptIdMapping'));
@@ -49,6 +49,7 @@ export const renderTable = (data, source) => {
                     </button>
                     <ul class="dropdown-menu" id="dropdownMenuButtonSites" aria-labelledby="dropdownMenuButton">
                         <li><a class="dropdown-item" data-siteKey="allResults" id="all">All</a></li>
+                        <li><a class="dropdown-item" data-siteKey="BSWH" id="BSWH">Baylor Scott & White Health</a></li>
                         <li><a class="dropdown-item" data-siteKey="hfHealth" id="hfHealth">Henry Ford HS</a></li>
                         <li><a class="dropdown-item" data-siteKey="hPartners" id="hPartners">Health Partners</a></li>
                         <li><a class="dropdown-item" data-siteKey="kpGA" id="kpGA">KP GA</a></li>
@@ -59,7 +60,6 @@ export const renderTable = (data, source) => {
                         ${((location.host !== urls.prod) && (location.host !== urls.stage)) ? `<li><a class="dropdown-item" data-siteKey="nci" id="nci">NCI</a></li>` : ``}
                         <li><a class="dropdown-item" data-siteKey="snfrdHealth" id="snfrdHealth">Sanford Health</a></li>
                         <li><a class="dropdown-item" data-siteKey="uChiM" id="uChiM">UofC Medicine</a></li>
-                        <li>< a class="dropdown-item" data-siteKey="BSWH" id="BSWH">Baylor Scott & White Health</a></li>
                     </ul>
                 </div>
                 <div class="btn-group .btn-group-lg" role="group" aria-label="Basic example" style="margin-left:25px; padding: 10px 20px; border-radius: 10px; width:25%; height:25%;">
@@ -685,6 +685,28 @@ const tableTemplate = (data, showButtons) => {
                         :
                         template += `<td>${participant['state'][fieldMapping.henryFReportedRace.toString()] ? `Unavailable/Unknown` : ``}</td>`)
                     )
+            : (x === fieldMapping.bswhReportedRaceEthnicity.toString()) ? (
+                (
+                    (participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] === fieldMapping.whiteNonHispanic) ?
+                        template += `<td>${participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] ? `White non-Hispanic` : ``}</td>`
+                        : (participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] === fieldMapping.blackNonHispanic) ?
+                        template += `<td>${participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] ? `Black non-Hispanic` : ``}</td>`
+                        : (participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] === fieldMapping.hispanicLatino) ?
+                        template += `<td>${participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] ? `Hispanic/Latino` : ``}</td>`
+                        : (participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] === fieldMapping.asian) ?
+                        template += `<td>${participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] ? `Asian` : ``}</td>`
+                        : (participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] === fieldMapping.americanIndianOrAlaskanNative) ?
+                        template += `<td>${participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] ? `American Indian or Alaskan Native` : ``}</td>`
+                        : (participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] === fieldMapping.nativeHawaiianOrOtherPacificIslander) ?
+                        template += `<td>${participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] ? `Native Hawaiian or Other Pacific Islander` : ``}</td>`
+                        : (participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] === fieldMapping.multiRacial) ?
+                        template += `<td>${participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] ? `Multi-racial` : ``}</td>`
+                        : (participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] === fieldMapping.other) ?
+                        template += `<td>${participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] ? `Other` : ``}</td>`
+                        : (participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] === fieldMapping.unavailable) ?
+                        template += `<td>${participant['state'][fieldMapping.bswhReportedRaceEthnicity.toString()] ? `Unavailable/Unknown` : ``}</td>` 
+                        : template += `<td>${``}</td>`)
+                )
             : (x === fieldMapping.preConsentOptOut.toString()) ? (
                 ( participant['state'][fieldMapping.preConsentOptOut.toString()] === fieldMapping.yes ) ?
                 template += `<td>${participant['state'][fieldMapping.preConsentOptOut.toString()] ? `Yes` : ``}</td>`

--- a/siteManagerDashboard/participantLookup.js
+++ b/siteManagerDashboard/participantLookup.js
@@ -61,6 +61,7 @@ export function renderParticipantSearch() {
                                 </button>
                                 <ul class="dropdown-menu" id="dropdownMenuLookupSites" aria-labelledby="dropdownMenuButton">
                                     <li><a class="dropdown-item" data-siteKey="allResults" id="all">All</a></li>
+                                    <li><a class="dropdown-item" data-siteKey="BSWH" id="BSWH">Baylor Scott & White Health</a></li>
                                     <li><a class="dropdown-item" data-siteKey="hfHealth" id="hfHealth">Henry Ford HS</a></li>
                                     <li><a class="dropdown-item" data-siteKey="hPartners" id="hPartners">Health Partners</a></li>
                                     <li><a class="dropdown-item" data-siteKey="kpGA" id="kpGA">KP GA</a></li>
@@ -71,7 +72,6 @@ export function renderParticipantSearch() {
                                     ${((location.host !== urls.prod) && (location.host !== urls.stage)) ? `<li><a class="dropdown-item" data-siteKey="nci" id="nci">NCI</a></li>` : ``}
                                     <li><a class="dropdown-item" data-siteKey="snfrdHealth" id="snfrdHealth">Sanford Health</a></li>
                                     <li><a class="dropdown-item" data-siteKey="uChiM" id="uChiM">UofC Medicine</a></li>
-                                    <li><a class="dropdown-item" data-siteKey="BSWH" id="BSWH">Baylor Scott & White Health</a></li>
                                 </ul>
                             </div>
                             <div id="search-failed" class="search-not-found" hidden>

--- a/siteManagerDashboard/participantSummary.js
+++ b/siteManagerDashboard/participantSummary.js
@@ -308,7 +308,7 @@ const hippaHandler = (participant) => {
                     <td>${participant[fieldMapping.hippaDate] && humanReadableMDY(participant[fieldMapping.hippaDate])}</td>
                     <td>${participant[fieldMapping.hipaaVersion]}</td>
                     <td>N/A</td>
-                    <td><a style="color: blue; text-decoration: underline;" target="_blank" id="downloadCopyHIPAA">Download Link</a></td>
+                    <td><a style="color: blue; text-decoration: underline; cursor: pointer;" target="_blank" id="downloadCopyHIPAA">Download Link</a></td>
     ` ) : 
     (
         template +=`<td><i class="fa fa-times fa-2x" style="color: red;"></i></td>


### PR DESCRIPTION
The pull request is related to the following links:

Add BSWH reported race/ethnicity button field on All Participants page
- https://github.com/episphere/connect/issues/1035

Fix dropdown for BSWH and add cursor pointer on HIPAA consent copy link on hover
- https://github.com/episphere/connect/issues/884#issuecomment-2130060601 
---

Code Changes:
- Added `bswhReportedRaceEthnicity` reference to `fieldToConceptIdMapping.js` for bswh reported race/ethnicity field button
- Added new race/ethnicity references in `fieldToConceptIdMapping.js`
- Added logic to display bswh participant's reported race/ethnicity on table
- Adjusted order of BSWH on dropdown so it's alphabetical relative to the filter options

---
BSWH in filter dropdown option
![Screenshot 2024-06-07 at 2 07 40 PM](https://github.com/episphere/dashboard/assets/33293205/d1845627-2e2a-4c23-b73c-6f74e0b815a8)

BSWH reported race/ethnicity button field
![Screenshot 2024-06-07 at 2 08 04 PM](https://github.com/episphere/dashboard/assets/33293205/38844b77-a444-48e9-b933-624cb7a5a5aa)

BSWH reported race/ethnicity column added and date displayed
![Screenshot 2024-06-07 at 2 08 31 PM](https://github.com/episphere/dashboard/assets/33293205/c0d8afc2-3305-4e53-884e-738ac6f9e161)


