### PR TITLE
Display version number on footer

### DIFF
--- a/siteManagerDashboard/appVersion.js
+++ b/siteManagerDashboard/appVersion.js
@@ -1,0 +1,4 @@
+const appVersion = {
+    versionNumber: 'v1.6.5'
+}
+export default appVersion

--- a/siteManagerDashboard/assets/css/dashboard.css
+++ b/siteManagerDashboard/assets/css/dashboard.css
@@ -340,3 +340,7 @@ table {
     border-radius: .25rem;
     width: 100px;
   }
+
+  #appVersion {
+    font-size: 0.8rem;
+  }

--- a/siteManagerDashboard/index.js
+++ b/siteManagerDashboard/index.js
@@ -20,6 +20,7 @@ import { SSOConfig as devSSOConfig} from './dev/identityProvider.js';
 import { SSOConfig as stageSSOConfig} from './stage/identityProvider.js';
 import { SSOConfig as prodSSOConfig} from './prod/identityProvider.js';
 import { appState } from './stateManager.js';
+import appVersion from './appVersion.js';
 
 let saveFlag = false;
 let counter = 0;
@@ -1154,3 +1155,13 @@ const activityCheckController = () => {
     document.onmousemove = resetTimer;
     document.onkeypress = resetTimer;
 };
+
+(function displayAppVersion() {
+    document.addEventListener('DOMContentLoaded', function() {
+        const contentWrapper = document.querySelector('.footer-content .content-wrapper');
+
+        const newElement = document.createElement('div');
+        newElement.innerHTML = `<p id="appVersion">${appVersion.versionNumber}</p>`;
+        contentWrapper.appendChild(newElement);
+    });
+})();


### PR DESCRIPTION
This pull request is related to the following:
- https://github.com/episphere/connect/issues/621
 
Problem: Display the app version number

Code changes:
- added an `appVersion.js` file, 
- initialized a variable named `appVersion`, assigned object to `appVersion` where the object has the version number of the current app, appVersion will be exported and imported
- added `displayAppVersion` function in `index.js` file to display app version number when HTML document is loaded and parsed
- added #appVersion id selector to `style.css` file 

Note: version number is pulled from most current repo Releases page on github at time of this Pull request ([SMDB github releases page](https://github.com/episphere/dashboard/releases)
![Screenshot 2024-07-22 at 9 36 12 AM](https://github.com/user-attachments/assets/20986f7e-082e-4be2-aaa4-5ff305089beb)
